### PR TITLE
Fix kwargs iteration in settings builders

### DIFF
--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -105,7 +105,7 @@ def settings_builder_x265(
     # Don't need to change these lol
     settings += " --no-sao --no-sao-non-deblock --no-strong-intra-smoothing --no-open-gop"
 
-    for k, v in kwargs:
+    for k, v in kwargs.items():
         prefix = "--"
         if k.startswith("_"):
             prefix = "-"
@@ -150,7 +150,7 @@ def settings_builder_x264(
         deblock = f"{str(deblock[0])}:{str(deblock[1])}"
     settings += f" --deblock={deblock}"
 
-    for k, v in kwargs:
+    for k, v in kwargs.items():
         prefix = "--"
         if k.startswith("_"):
             prefix = "-"


### PR DESCRIPTION
otherwise:
```python
settings_builder_x265(merange=57)
```
```
Traceback (most recent call last):
  File "01.py", line 99, in <module>
    settings = settings_builder_x265(
               ^^^^^^^^^^^^^^^^^^^^^^
  File ".venv\Lib\site-packages\vsmuxtools\video\settings.py", line 108, in settings_builder_x265
    for k, v in kwargs:
        ^^^^
ValueError: too many values to unpack (expected 2)
```
