### PR TITLE
src_file: fix PathLike typing

### DIFF
--- a/vsmuxtools/utils/src.py
+++ b/vsmuxtools/utils/src.py
@@ -1,5 +1,4 @@
 import shutil as sh
-from os import PathLike
 from pathlib import Path
 from typing import Callable
 from fractions import Fraction
@@ -24,7 +23,7 @@ __all__ = ["src_file", "SRC_FILE", "FileInfo", "src", "frames_to_samples", "f2s"
 
 
 class src_file:
-    file: PathLike
+    file: Path
     force_lsmas: bool = False
     trim: Trim = None
     idx: Callable[[str], vs.VideoNode] | None = None


### PR DESCRIPTION
I don't know the context behind 9a7fbd6, so if I'm regressing something and you recall what it was just let me know and I'll adjust this. `muxtools.PathLike` was already being imported here so importing `os.PathLike` as well seems like an error.

This fixes a type error when trying to use string paths:

```python
from vsmuxtools import src_file

src_file("/path/to/file.m2ts")
# test.py:3: error: Argument 1 to "src_file" has incompatible type "str"; expected "PathLike[Any] | GlobSearch"  [arg-type]
```

---

As a side note, it seems like `muxtools.PathLike` is used more like a union type rather than the type variable it is. This leads to oddities like:
```python
from vsmuxtools import Chapters

Chapters("/path/to/chapters", Path("/path/to/timecodes"))
# test.py:3: error: Value of type variable "PathLike" of "Chapters" cannot be "object"  [type-var]
```
where one can't mix different `muxtools.PathLike`s (in the few functions that take multiple) even though it doesn't really matter here. But since I'm not sure on the intention behind it I won't PR changing it unless you agree.