### PR TITLE
utils: improve `Zone` typing

### DIFF
--- a/vsmuxtools/utils/types.py
+++ b/vsmuxtools/utils/types.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 __all__ = ["LosslessPreset"]
 
-Zone = tuple[int, int, float | str, str | None]
+Zone = tuple[int, int, float | str] | tuple[int, int, str, float | int | str]
 
 
 class LosslessPreset(Enum):

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -1,9 +1,7 @@
-from genericpath import isfile
 import re
 import os
-from tracemalloc import start
 from muxtools import error, PathLike, ensure_path, warn
-from vstools import vs, Matrix, Primaries, Transfer, ColorRange, ChromaLocation, get_prop, Colorspace
+from vstools import vs, Matrix, Primaries, Transfer, ColorRange, ChromaLocation
 from ..utils.types import Zone
 
 __all__ = ["settings_builder_x265", "settings_builder_x264", "sb", "sb265", "sb264"]


### PR DESCRIPTION
The current typing only allows for tuples of length 4, but shorter tuples (omitting the 3rd `str` element) work and are documented. Sample mypy output using zones from https://muxtools.vodes.pw/guide/encode-video/#basic-usage:

```python
from vsmuxtools import x264, x265

x264(zones=[(100, 400, "crf", 15)])
# error: List item 0 has incompatible type "tuple[int, int, str, int]"; expected "tuple[int, int, float | str, str | None]"

x265(zones=[(100, 400, 0.5)])
# error: List item 0 has incompatible type "tuple[int, int, float]"; expected "tuple[int, int, float | str, str | None]"
```

And I don't think the 4th element is supposed to be a `str` either. To fix this we union the 3-element tuple case with the 4-element one.

I also removed some unused imports from `video/settings.py` just because I noticed them while looking at places where `Zone` is referenced.