### PR TITLE
Add zone normalizing

### DIFF
--- a/vsmuxtools/video/encoders/base.py
+++ b/vsmuxtools/video/encoders/base.py
@@ -153,7 +153,7 @@ class SupportsQP(VideoEncoder):
         start_frame = sum(keyframes)
         info(f"Starting encode at frame {start_frame}")
 
-        # TODO: Adjust existing zones to the new start frame
+        # TODO: Normalize and adjust existing zones to the new start frame
 
         clip = clip[start_frame:]
         self._encode_clip(clip, fout, self._get_qpfile(start_frame), start_frame)

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -7,7 +7,7 @@ from muxtools.utils.dataclass import dataclass, allow_extra
 
 from .base import SupportsQP, VideoEncoder
 from .types import LosslessPreset
-from ..settings import shift_zones, zones_to_args
+from ..settings import shift_zones, zones_to_args, norm_zones
 
 __all__ = ["x264", "x265", "LosslessX264", "SVTAV1"]
 
@@ -54,6 +54,7 @@ class x264(SupportsQP):
         if self.settings:
             args.extend(self.settings if isinstance(self.settings, list) else shlex.split(self.settings))
         if self.zones:
+            self.zones = norm_zones(clip, self.zones)
             if start_frame:
                 self.zones = shift_zones(self.zones, start_frame)
             args.extend(zones_to_args(self.zones, False))
@@ -117,6 +118,7 @@ class x265(SupportsQP):
         if self.settings:
             args.extend(self.settings if isinstance(self.settings, list) else shlex.split(self.settings))
         if self.zones:
+            self.zones = norm_zones(clip, self.zones)
             if start_frame:
                 self.zones = shift_zones(self.zones, start_frame)
             args.extend(zones_to_args(self.zones, True))

--- a/vsmuxtools/video/encoders/types.py
+++ b/vsmuxtools/video/encoders/types.py
@@ -2,7 +2,8 @@ from enum import IntEnum
 
 __all__ = ["LosslessPreset", "ProResProfile"]
 
-Zone = tuple[int, int, float | str] | tuple[int, int, str, float | int | str]
+ZoneFrame = tuple[int, None]
+Zone = tuple[ZoneFrame, ZoneFrame, float | str] | tuple[ZoneFrame, ZoneFrame, str, float | int | str]
 
 
 class LosslessPreset(IntEnum):

--- a/vsmuxtools/video/encoders/types.py
+++ b/vsmuxtools/video/encoders/types.py
@@ -1,8 +1,9 @@
 from enum import IntEnum
+from typing import Union
 
 __all__ = ["LosslessPreset", "ProResProfile"]
 
-ZoneFrame = tuple[int, None]
+ZoneFrame = Union[int, None]
 Zone = tuple[ZoneFrame, ZoneFrame, float | str] | tuple[ZoneFrame, ZoneFrame, str, float | int | str]
 
 

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -46,14 +46,20 @@ def norm_zones(clip_or_max_frames: vs.VideoNode | int, zones: Zone | list[Zone] 
 
         start, end, *params = zone
 
-        if start < 0:
+        if start is None:
+            start = 0
+        elif isinstance(start, int) and start < 0:
             start = max_frames - abs(start)
 
-        if end < 0:
+        if end is None:
+            end = max_frames - 1
+        elif isinstance(end, int) and end < 0:
             end = max_frames - abs(end)
 
         if start > end:
             raise CustomValueError(f"Zone '{zone}' start frame after end frame!", norm_zones, f"{start} > {end}")
+
+        assert isinstance(start, int) and isinstance(end, int)
 
         newzones.append(cast(Zone, (start, min(end, max_frames - 1), *params)))
 

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -57,11 +57,9 @@ def norm_zones(clip_or_max_frames: vs.VideoNode | int, zones: Zone | list[Zone] 
             end = max_frames - abs(end)
 
         if start > end:
-            raise CustomValueError(f"Zone '{zone}' start frame after end frame!", norm_zones, f"{start} > {end}")
+            raise CustomValueError(f"Zone '{zone}' start frame is after end frame!", norm_zones, f"{start} > {end}")
 
-        assert isinstance(start, int) and isinstance(end, int)
-
-        newzones.append(cast(Zone, (start, min(end, max_frames - 1), *params)))
+        newzones.append(cast(Zone, (start, min(end, max_frames - 1), *params)))  # type:ignore[type-var]
 
     return newzones
 

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -1,7 +1,11 @@
-import re
 import os
-from muxtools import error, PathLike, ensure_path, warn
-from vstools import vs, Matrix, Primaries, Transfer, ColorRange, ChromaLocation
+import re
+from typing import cast
+
+from muxtools import PathLike, ensure_path, error, warn
+from vstools import (ChromaLocation, ColorRange, CustomValueError, Matrix,
+                     Primaries, Transfer, vs)
+
 from .encoders.types import Zone
 
 __all__ = ["settings_builder_x265", "settings_builder_x264", "sb", "sb265", "sb264"]
@@ -14,6 +18,46 @@ def is_full_zone(zone: Zone) -> bool:
         return True
     else:
         return False
+
+
+def norm_zones(clip_or_max_frames: vs.VideoNode | int, zones: Zone | list[Zone] | None) -> list[Zone]:
+    """
+    Normalize zones to be within the clip's range.
+
+    :param clip_or_max_frames:      The clip or a max frame count to normalize to.
+    :param zones:                   The zones to normalize.
+
+    :return:                        The normalized zones.
+    """
+
+    if not zones:
+        return []
+
+    max_frames = clip_or_max_frames if isinstance(clip_or_max_frames, int) else clip_or_max_frames.num_frames
+
+    if not isinstance(zones, list):
+        zones = [zones]
+
+    newzones = list[Zone]()
+
+    for zone in zones:
+        if not is_full_zone(zone):
+            continue
+
+        start, end, *params = zone
+
+        if start < 0:
+            start = max_frames - abs(start)
+
+        if end < 0:
+            end = max_frames - abs(end)
+
+        if start > end:
+            raise CustomValueError(f"Zone '{zone}' start frame after end frame!", norm_zones, f"{start} > {end}")
+
+        newzones.append(cast(Zone, (start, min(end, max_frames - 1), *params)))
+
+    return newzones
 
 
 def shift_zones(zones: Zone | list[Zone] | None, start_frame: int = 0) -> list[Zone] | None:

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -41,9 +41,6 @@ def norm_zones(clip_or_max_frames: vs.VideoNode | int, zones: Zone | list[Zone] 
     newzones = list[Zone]()
 
     for zone in zones:
-        if not is_full_zone(zone):
-            continue
-
         start, end, *params = zone
 
         if start is None:


### PR DESCRIPTION
This PR adds a basic zone normalizing function and also calls this in x264/x265, as well as adds a note about it to a TODO reminder.

The normalizing is simply a check on whether the zones are valid;

- If either the start or end times are negative values, assume this is relative to the total frame count
- If the start time is after the end time, raise an error

I was going to add support for None, but I'm not sure if you want to support that. lmk if you do, and I'll add that to this PR as well.