### PR TITLE
Refactor source funcs to use enum and soft-remove older force_* params

### DIFF
--- a/vsmuxtools/utils/source.py
+++ b/vsmuxtools/utils/source.py
@@ -87,9 +87,12 @@ class src_file:
         """
         Custom `FileInfo` kind of thing for convenience
 
-        :param file:            Either a string based filepath or a Path object
-        :param trim:            Can be a single trim or a sequence of trims.
-        :param idx:             Indexer for the input file. Pass a function that takes a string in and returns a vs.VideoNode.
+        :param file:                    Either a string based filepath or a Path object
+        :param trim:                    Can be a single trim or a sequence of trims.
+        :param preview_sourcefilter:    Source filter to be used when previewing using vspreview.
+                                        `None` will make it fall back to `sourcefilter`.
+        :param sourcefilter:            Source filter to be used otherwise.
+        :param idx:                     Custom indexer for the input file. Pass a function that takes a string in and returns a vs.VideoNode.
         """
         if isinstance(file, Sequence) and not isinstance(file, str) and len(file) == 1:
             file = file[0]
@@ -281,11 +284,12 @@ def src(
     Uses lsmas for previewing and bestsource otherwise.
     Still supports dgi files directly if dgdecodenv is installed to not break existing scripts.
 
-    :param filepath:        Path to video or dgi file
-    :param force_lsmas:     Force the use of lsmas.LWLibavSource
-    :param force_bs:        Force the use of bs.VideoSource. This takes priority over the force_lsmas param.
-    :param kwargs:          Other arguments you may or may not wanna pass to the indexer.
-    :return:                Video Node
+    :param filepath:                Path to video or dgi file
+    :param preview_sourcefilter:    Source filter to be used when previewing using vspreview.
+                                    `None` will make it fall back to `sourcefilter`.
+    :param sourcefilter:            Source filter to be used otherwise.
+    :param kwargs:                  Other arguments you may or may not wanna pass to the indexer.
+    :return:                        Video Node
     """
     filePath = ensure_path_exists(filePath, src)
     dgiFile = filePath.with_suffix(".dgi")


### PR DESCRIPTION
Intends to fix #8. @NSQY

Feedback welcome.

Soft-removal in the sense that the `force_lsmas` and `force_bs` params will print a warning until a new minor (not patch) version bump, set `preview_sourcefilter` to `None` and `sourcefilter` to their respective one.
See https://github.com/Jaded-Encoding-Thaumaturgy/vs-muxtools/pull/9/commits/3bec4c3e1f333ddcd592df55273b448df4ab2510#diff-716bfc7ab72d7320dd0101890fcaa11ef2004cf164113d2ac9746001cb4def51R305-R315

----

Behavior when used:

![WindowsTerminal_qqup1xKXnm](https://github.com/user-attachments/assets/eb624e52-9a8c-48fc-9e29-eb4fa6361653)

![WindowsTerminal_EUP7E0yCG0](https://github.com/user-attachments/assets/58da49fe-8ec6-431d-8291-7cf6987e7a3a)
