### PR TITLE
build-backend: switch from setuptools to hatchling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,24 +16,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install build tools
-        run: |
-          python -m pip install build setuptools twine wheel --user
-        continue-on-error: false
-      - name: Build source and wheel
-        id: build
-        run: |
-          python -m build --outdir dist/
-        continue-on-error: true
-      - name: Check the output
-        run: |
-          python -m twine check --strict dist/*
-        continue-on-error: false
-      - name: Die on failure
-        if: steps.build.outcome != 'success'
-        run: exit 1
+      - name: Build
+        run: pipx run build
+
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.AUTH_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 readme = "README.md"
-license = { text = "MPL 2.0" }
+license = "MPL-2.0"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project.urls]
 "Source Code" = "https://github.com/Vodes/vs-muxtools"


### PR DESCRIPTION
Same reasoning: https://github.com/Jaded-Encoding-Thaumaturgy/muxtools/pull/33