### PR TITLE
Fix get_render_progress import

### DIFF
--- a/vsmuxtools/utils/audio.py
+++ b/vsmuxtools/utils/audio.py
@@ -2,7 +2,7 @@ import struct
 import numpy as np
 from enum import IntEnum
 from typing import BinaryIO, Optional
-from vstools import get_render_progress, vs
+from vstools import vs
 
 __all__ = ["audio_async_render", "WaveHeader"]
 
@@ -70,6 +70,8 @@ def audio_async_render(
                         If empty or ``None``, no progress display.
     """
     if progress:
+        from vstools.functions.progress import get_render_progress
+
         p = get_render_progress()
         task = p.add_task(progress, total=audio.num_frames)
         p.start()


### PR DESCRIPTION
`get_render_progress` [isn't imported for the whole package anymore](https://github.com/Jaded-Encoding-Thaumaturgy/vs-jetpack/commit/0979ffa8e0706c233ee45e55301504edc13ef18b#diff-8938f5b12124862b15b1fb8797d95fbf247c5e9e067e42cc5ba6d10c3011ef0d) to improve initialization speed.