### PR TITLE
SVTAV1: Refresh and add two SVT-AV1 based settings_builder

### DIFF
--- a/vsmuxtools/utils/source.py
+++ b/vsmuxtools/utils/source.py
@@ -432,18 +432,18 @@ def generate_qp_file(clip: vs.VideoNode, start_frame: int = 0) -> str:
 
 
 def generate_svt_av1_keyframes(
-        clip: vs.VideoNode,
-        start_frame: int = 0,
-        min_scene_length: int = 129,
-        min_still_scene_length: int = 193,
-        max_scene_length: int = 257,
-    ) -> np.ndarray[tuple[Any, ...], np.dtype[np.uint32]]:
+    clip: vs.VideoNode,
+    start_frame: int = 0,
+    min_scene_length: int = 129,
+    min_still_scene_length: int = 193,
+    max_scene_length: int = 257,
+) -> np.ndarray[tuple[Any, ...], np.dtype[np.uint32]]:
     """
     Run `generate_keyframes`, and then filter the WWXD keyframe result for SVT-AV1 derived encoders.
 
-    A huge contribution to the efficiency of SVT-AV1 derived encoders comes from its referencing system. 
-    SVT-AV1 derived encoders by default have a 32 frame hierarchical structure.  
-    It will first encode frame 0 as a key frame, followed by frame 32 referencing frame 0.  
+    A huge contribution to the efficiency of SVT-AV1 derived encoders comes from its referencing system.
+    SVT-AV1 derived encoders by default have a 32 frame hierarchical structure.
+    It will first encode frame 0 as a key frame, followed by frame 32 referencing frame 0.
     Since later frames will all be referencing these frames, these frames of the lowest temporal layer will be given very good q.
     After that, the encoder will continue with frame 16, referencing both frame 0 and frame 32.
     And then after frame 16, it'll be frame 8, frame 4, frame 2, frame 1, in this order.
@@ -463,7 +463,7 @@ def generate_svt_av1_keyframes(
     diff_clip = clip.std.PlaneStats(clip[0] + clip, plane=0, prop="Luma")
 
     frames.append(len(clip))
-    head = -1 # Because the result from generate_keyframes doesn't have `0`
+    head = -1  # Because the result from generate_keyframes doesn't have `0`
     current_frame = 0
     svt_av1_frames = [0]
     while head < len(frames) - 1:
@@ -476,7 +476,7 @@ def generate_svt_av1_keyframes(
 
             else:
                 current_frame = frames[head]
-                svt_av1_frames.append(current_frame) # Only to get popped
+                svt_av1_frames.append(current_frame)  # Only to get popped
 
         elif frames[head] - current_frame <= max_scene_length:
             available_frames = []
@@ -505,8 +505,12 @@ def generate_svt_av1_keyframes(
         # If WWXD doesn't select anything within max_scene_length, try finding good frames using diffs.
         else:
             selected_frame = None
-            diffs = np.array([frame.props["LumaDiff"] for frame in diff_clip[current_frame+min_still_scene_length:
-                                                                             current_frame+max_scene_length+1].frames()])
+            diffs = np.array(
+                [
+                    frame.props["LumaDiff"]
+                    for frame in diff_clip[current_frame + min_still_scene_length : current_frame + max_scene_length + 1].frames()
+                ]
+            )
             windows = sliding_window_view(diffs, 25)
             median = np.median(windows, axis=1).reshape((-1, 1))
             mad = np.median(np.abs(windows - median), axis=1).reshape((-1, 1))

--- a/vsmuxtools/utils/source.py
+++ b/vsmuxtools/utils/source.py
@@ -32,6 +32,8 @@ from muxtools import (
     warn,
     ParsedFile,
 )
+import numpy as np
+from numpy.lib.stride_tricks import sliding_window_view
 
 from muxtools.audio.preprocess import classproperty
 
@@ -427,3 +429,108 @@ def generate_qp_file(clip: vs.VideoNode, start_frame: int = 0) -> str:
     clean_temp_files()
 
     return str(filepath.resolve())
+
+
+def generate_svt_av1_keyframes(
+        clip: vs.VideoNode,
+        start_frame: int = 0,
+        min_scene_length: int = 129,
+        min_still_scene_length: int = 193,
+        max_scene_length: int = 257,
+    ) -> np.ndarray[tuple[Any, ...], np.dtype[np.uint32]]:
+    """
+    Run `generate_keyframes`, and then filter the WWXD keyframe result for SVT-AV1 derived encoders.
+
+    A huge contribution to the efficiency of SVT-AV1 derived encoders comes from its referencing system. 
+    SVT-AV1 derived encoders by default have a 32 frame hierarchical structure.  
+    It will first encode frame 0 as a key frame, followed by frame 32 referencing frame 0.  
+    Since later frames will all be referencing these frames, these frames of the lowest temporal layer will be given very good q.
+    After that, the encoder will continue with frame 16, referencing both frame 0 and frame 32.
+    And then after frame 16, it'll be frame 8, frame 4, frame 2, frame 1, in this order.
+    The frames in higher temporal layer will be given a bad q, mostly relying on information in the frame they reference to get a good encoding quality.
+    It's very efficient to allow SVT-AV1 derived encoders to build a full hierarchical structure like this, with lower level frames being given a good q, and higher level frames relying on referencing and saving bitrate.
+    For scene detection, the scenes that gives the best efficiency should have a length of `(integer * 32) + 1`, followed by scenes that has a length of `(integer * 16) + 1`, and then `8`, and then `4`, et cetera.
+
+    Additionally, since both frame 0 and frame 32 will be given very good q, if there were a real scene change in the middle of this 32 frame structure, it will be handled well because frame 32 will certainly be given a good enough q to encode the new scene.
+    On the other hand, making too much scenecut in scene detection, resulting in a lot of smaller and incomplete hierarchical strctures in each scene is generally a very bad idea.
+    Since WWXD often has the tendency to place way too much scenecuts in challenging sections, the purpose of this function is to filter the result from WWXD and create scenes that has more efficient hierarchical structure as much as possible.
+    """
+    frames = generate_keyframes(clip, start_frame)
+
+    if start_frame:
+        clip = clip[start_frame:]
+
+    diff_clip = clip.std.PlaneStats(clip[0] + clip, plane=0, prop="Luma")
+
+    frames.append(len(clip))
+    head = -1 # Because the result from generate_keyframes doesn't have `0`
+    current_frame = 0
+    svt_av1_frames = [0]
+    while head < len(frames) - 1:
+        head += 1
+
+        # Choosing between WWXD selected frames within the limit of min_scene_length and max_scene_length
+        if frames[head] - current_frame < min_scene_length:
+            if head != len(frames) - 1:
+                continue
+
+            else:
+                current_frame = frames[head]
+                svt_av1_frames.append(current_frame) # Only to get popped
+
+        elif frames[head] - current_frame <= max_scene_length:
+            available_frames = []
+            for looka_head in range(head, len(frames)):
+                if frames[looka_head] - current_frame <= max_scene_length:
+                    available_frames.append(frames[looka_head])
+                else:
+                    break
+
+            selected_head = None
+            for structure in [32, 16, 8, 4, 2]:
+                for available_head in range(len(available_frames) - 1, -1, -1):
+                    if (available_frames[available_head] - current_frame) % structure == 1:
+                        selected_head = available_head
+                        break
+                if selected_head is not None:
+                    break
+
+            if selected_head is None:
+                selected_head = len(available_frames) - 1
+
+            head = head + selected_head
+            current_frame = frames[head]
+            svt_av1_frames.append(current_frame)
+
+        # If WWXD doesn't select anything within max_scene_length, try finding good frames using diffs.
+        else:
+            selected_frame = None
+            diffs = np.array([frame.props["LumaDiff"] for frame in diff_clip[current_frame+min_still_scene_length:
+                                                                             current_frame+max_scene_length+1].frames()])
+            windows = sliding_window_view(diffs, 25)
+            median = np.median(windows, axis=1).reshape((-1, 1))
+            mad = np.median(np.abs(windows - median), axis=1).reshape((-1, 1))
+            thr = (median + 3.0 * mad).reshape((-1,))
+            thr = np.concatenate((np.full((12,), thr[0]), thr, np.full((12,), thr[-1])))
+            motion_frames = np.argwhere(diffs > thr).reshape((-1,))
+            motion_frames += current_frame + min_still_scene_length
+
+            if motion_frames.shape[0] != 0:
+                for structure in [32, 16, 8]:
+                    for frame in motion_frames[::-1]:
+                        if (frame - current_frame) % structure == 1:
+                            selected_frame = frame
+                            break
+                    if selected_frame is not None:
+                        break
+
+            if selected_frame is None:
+                selected_frame = current_frame + max_scene_length
+
+            head -= 1
+            current_frame = selected_frame
+            svt_av1_frames.append(current_frame)
+
+    svt_av1_frames.pop()
+
+    return np.asarray(svt_av1_frames, dtype=np.uint32)

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -244,7 +244,7 @@ class SVTAV1(VideoEncoder):
         output = make_output("svtav1", ext="ivf", user_passed=outfile)
 
         tags = dict[str, str](ENCODER=str(self._encoder_id))
-        args = [self.executable, "-i", "-", "--output", str(output)]
+        args = [self.executable, "--input", "-", "--output", str(output)]
 
         if not any(key in self.get_custom_args_dict() for key in {"preset", "speed"}):
             self.update_custom_args(preset=2)

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -256,14 +256,13 @@ class SVTAV1(VideoEncoder):
             if "force_key_frames" in self.get_custom_args_dict():
                 raise error("Scene detection from `sd_clip` can't be applied when `--force-key-frames` encoder parameter is already specified.", self)
 
-            if "Essential" in self._encoder_id:
+            if "Essential" in str(self._encoder_id):
                 info(
                     "Disabling built-in scene change detection of SVT-AV1-Essential in favor of muxtools implementation.\nDon't pass 'sd_clip' if this is undesirable.",
                     self,
                 )
 
-            self.update_custom_args(scd=0)
-            self.update_custom_args(keyint=0)
+            self.update_custom_args(keyint=0, scd=0)
 
             sd_clip = self.sd_clip if isinstance(self.sd_clip, vs.VideoNode) else self.sd_clip.src_cut
 

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -240,7 +240,7 @@ class SVTAV1(VideoEncoder):
         output = make_output("svtav1", ext="ivf", user_passed=outfile)
 
         tags = dict[str, str](ENCODER=cast(str, self._encoder_id))
-        args = [self.executable, "-i", "-", "-b", str(output)]
+        args = [self.executable, "-i", "-", "--output", str(output)]
 
         # user parameters
         args.extend(self.get_custom_args())

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from muxtools import get_executable, VideoFile, PathLike, make_output, warn, get_setup_attr, ensure_path, info, get_workdir, error
 from muxtools.utils.env import get_binary_version
 from muxtools.utils.dataclass import dataclass, allow_extra
-from typing import cast
 import numpy as np
 
 from .base import SupportsQP, VideoEncoder

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -255,6 +255,15 @@ class SVTAV1(VideoEncoder):
             if "force_key_frames" in self.get_custom_args_dict():
                 raise error("Scene detection from `sd_clip` can't be applied when `--force-key-frames` encoder parameter is already specified.", self)
 
+            if "Essential" in self._encoder_id:
+                info(
+                    "Disabling built-in scene change detection of SVT-AV1-Essential in favor of muxtools implementation.\nDon't pass 'sd_clip' if this is undesirable.",
+                    self,
+                )
+                self.update_custom_args(scd=0)
+
+            self.update_custom_args(keyint=0)
+
             sd_clip = self.sd_clip if isinstance(self.sd_clip, vs.VideoNode) else self.sd_clip.src_cut
 
             cache = get_workdir() / "svt_av1_scene_detection_cache.npy"
@@ -279,8 +288,6 @@ class SVTAV1(VideoEncoder):
             else:
                 info("Attempting to use commandline parameter to specify keyframes since `-c` is already used...", self)
                 self.update_custom_args(force_key_frames=keyframes_str)
-
-            self.update_custom_args(keyint=-1)
 
         # photon_noise
         if self.photon_noise:

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -178,7 +178,7 @@ class LosslessX264(VideoEncoder):
 class SVTAV1(VideoEncoder):
     """
     Uses SvtAv1EncApp to encode clip to an AV1 stream.
-    
+
     Do not use this for high fidelity encoding.
 
     You can use the available `settings_builder`s for a set of default parameters.
@@ -190,6 +190,7 @@ class SVTAV1(VideoEncoder):
     :param photon_noise:    Add a basic layer of light photon noise on top, serving a similar role as regrain / dither.
                             For a layer of noise with different strength or coarseness, you can generate it yourself following the guide available in AV1 weeb server.
     """
+
     sd_clip: vs.VideoNode | src_file | None = None
     photon_noise: bool = True
     _encoder_id: str | None = None
@@ -201,7 +202,7 @@ class SVTAV1(VideoEncoder):
             self.affinity = []
 
         self._encoder_id = get_binary_version(self.executable, r"(\S+ v\S+) \((?:release|debug)\)", ["--version"])
-        
+
         if not self._encoder_id:
             raise error("Couldn't parse SvtAv1EncApp version!", self)
 
@@ -210,11 +211,14 @@ class SVTAV1(VideoEncoder):
                 warn(f"Unexpected encoder version: {self._encoder_id}.", self)
                 warn(f"Encoder version expected by the settings_builder: {self._settings_builder_id}.", self, 2)
 
-        if not self.sd_clip and \
-           not self._encoder_id.startswith("SVT-AV1-Essential"):
-            warn("Providing a clip or a file for scene detection is highly recommended, as most SVT-AV1 versions don't have proper scene detection.", self, 2)
+        if not self.sd_clip and not self._encoder_id.startswith("SVT-AV1-Essential"):
+            warn(
+                "Providing a clip or a file for scene detection is highly recommended, as most SVT-AV1 versions don't have proper scene detection.",
+                self,
+                2,
+            )
 
-    def encode(self, clip: vs.VideoNode, outfile: PathLike | None = None) -> VideoFile:  
+    def encode(self, clip: vs.VideoNode, outfile: PathLike | None = None) -> VideoFile:
         if clip.format.bits_per_sample > 10:
             warn("SVT-AV1 doesn't support a bit depth over 10.\nClip will be dithered to 10 bit.", self, 2)
             clip = finalize_clip(clip, 10)

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -5,12 +5,14 @@ from pathlib import Path
 from muxtools import get_executable, VideoFile, PathLike, make_output, warn, get_setup_attr, ensure_path, info, get_workdir, error
 from muxtools.utils.env import get_binary_version
 from muxtools.utils.dataclass import dataclass, allow_extra
+from typing import cast
+import numpy as np
 
 from .base import SupportsQP, VideoEncoder
 from .types import LosslessPreset
 from ..settings import shift_zones, zones_to_args, norm_zones
 
-from vsmuxtools.utils.source import generate_keyframes, src_file
+from vsmuxtools.utils.source import generate_svt_av1_keyframes, src_file
 
 __all__ = ["x264", "x265", "LosslessX264", "SVTAV1"]
 
@@ -175,49 +177,51 @@ class LosslessX264(VideoEncoder):
 @dataclass(config=allow_extra)
 class SVTAV1(VideoEncoder):
     """
-    Uses SVtAv1EncApp to encode clip to a av1 stream.\n
-    Do not use this for high fidelity encoding.\n
-    For better explanations of params, check the `--help` of the encoder or the gitlab wiki page.
+    Uses SvtAv1EncApp to encode clip to an AV1 stream.
+    
+    Do not use this for high fidelity encoding.
 
-    :param preset:          Encoder preset. Lower = slower & better
-                            The range is -1 to 13 for the regular SVTAV1 and -3 to 13 for SVTAV1-PSY
-    :param crf:             Constant rate factor, lower = better
-    :param tune:            The tuning metric. None = 2 for SVTAV1 and 3 for SVTAV1-PSY
+    You can use the available `settings_builder`s for a set of default parameters.
+    For better explanations of parameters, check the `Docs/Parameters.md` file in encoder's GitHub or GitLab.
 
-    :param qp_clip:         Can either be a straight up VideoNode or a SRC_FILE/FileInfo from this package.
-                            It is highly recommended to do this so you can force keyframes.
+    :param sd_clip:         Perform scene detection for the encoder.
+                            Can either be a straight up VideoNode or a SRC_FILE/FileInfo from this package.
+                            It is highly recommended for you to provide a clip or a file here for scene detection, as most SVT-AV1 forks don't have scene detection at all. The only exception is SVT-AV1-Essential which can perform its own scene detection.
+    :param photon_noise:    Add a basic layer of light photon noise on top, serving a similar role as regrain / dither.
+                            For a layer of noise with different strength or coarseness, you can generate it yourself following the guide available in AV1 weeb server.
     """
-
-    preset: int = 4
-    crf: int | float = 15
-    tune: int | None = None
-    qp_clip: vs.VideoNode | src_file | None = None
+    sd_clip: vs.VideoNode | src_file | None = None
+    photon_noise: bool = True
+    _encoder_id: str | None = None
+    _settings_builder_id: str | None = None
 
     def __post_init__(self):
         self.executable = get_executable("SvtAv1EncApp")
         if self.get_process_affinity() is False:
             self.affinity = []
-        if not self.qp_clip:
-            warn("It is highly recommended to force keyframes with this encoder!\nPlease pass a qp_clip param.", self, 2)
 
-    def _make_keyframes_config(self, clip: vs.VideoNode) -> Path | bool:
-        out = get_workdir() / "svt_keyframes.cfg"
-        if out.exists():
-            info("Reusing existing keyframes config.", self)
-            return out
-        info("Generating keyframes config file...", self)
+        self._encoder_id = get_binary_version(self.executable, r"(\S+ v\S+) \((?:release|debug)\)", ["--version"])
+        
+        if not self._encoder_id:
+            raise error("Couldn't parse SvtAv1EncApp version!", self)
 
-        keyframes = generate_keyframes(clip)
-        if not keyframes:
-            return False
-        keyframes_str = f"ForceKeyFrames : {'f,'.join([str(i) for i in keyframes])}f"
-        with open(out, "w", encoding="utf-8") as f:
-            f.write(keyframes_str)
+        if self._settings_builder_id is not None:
+            if not self._encoder_id.startswith(self._settings_builder_id):
+                warn(f"Unexpected encoder version: {self._encoder_id}.", self)
+                warn(f"Encoder version expected by the settings_builder: {self._settings_builder_id}.", self, 2)
 
-        info("Done", self)
-        return out
+        if not self.sd_clip and \
+           not self._encoder_id.startswith("SVT-AV1-Essential"):
+            warn("Providing a clip or a file for scene detection is highly recommended, as most SVT-AV1 versions don't have proper scene detection.", self, 2)
 
-    def encode(self, clip: vs.VideoNode, outfile: PathLike | None = None) -> VideoFile:
+    def encode(self, clip: vs.VideoNode, outfile: PathLike | None = None) -> VideoFile:  
+        if clip.format.bits_per_sample > 10:
+            warn("SVT-AV1 doesn't support a bit depth over 10.\nClip will be dithered to 10 bit.", self, 2)
+            clip = finalize_clip(clip, 10)
+        elif clip.format.bits_per_sample < 10:
+            warn("SVT-AV1 works best at 10 bit.\nClip will be converted to 10 bit", self, 2)
+            clip = finalize_clip(clip, 10)
+
         from vsmuxtools.video.clip_metadata import props_dict, SVT_AV1_RANGES
 
         clip_props = props_dict(clip, False, SVT_AV1_RANGES)
@@ -230,29 +234,74 @@ class SVTAV1(VideoEncoder):
                 raise error("AV1 only supports LEFT and TOPLEFT chroma locations!", self)
 
         output = make_output("svtav1", ext="ivf", user_passed=outfile)
-        encoder = get_binary_version(self.executable, r"(SVT-AV1.+?(?:v\d+.\d+.\d[^ ]+|[0-9a-f]{8,40}))", ["--version"])
-        assert encoder
 
-        tags = dict[str, str](ENCODER=encoder)
-        args = [self.executable, "-i", "-", "--output", str(output), "--preset", str(self.preset)]
-        if self.qp_clip:
-            qp_clip = self.qp_clip if isinstance(self.qp_clip, vs.VideoNode) else self.qp_clip.src_cut
-            keyframes_config = self._make_keyframes_config(qp_clip)
-            if keyframes_config:
-                args.extend(["--keyint", "-1", "-c", str(keyframes_config)])
+        tags = dict[str, str](ENCODER=cast(str, self._encoder_id))
+        args = [self.executable, "-i", "-", "-b", str(output)]
+
+        # user parameters
+        args.extend(self.get_custom_args())
+
+        if "--preset" not in args and "--speed" not in args:
+            args.extend(["--preset", "2"])
+        if "--crf" not in args and "--quality" not in args and "--qp" not in args and "--rc" not in args:
+            args.extend(["--crf", "22"])
+
+        # sd_clip
+        if self.sd_clip:
+            if "--force-key-frames" in args:
+                raise error("Scene detection from `sd_clip` can't be applied when `--force-key-frames` encoder parameter is already specified.", self)
+
+            sd_clip = self.sd_clip if isinstance(self.sd_clip, vs.VideoNode) else self.sd_clip.src_cut
+
+            cache = get_workdir() / "svt_av1_scene_detection_cache.npy"
+
+            if not cache.exists():
+                info("Performing scene detection...", self)
+                keyframes = generate_svt_av1_keyframes(sd_clip)
+                np.save(cache, keyframes)
+                info("Scene detection complete.", self)
             else:
-                warn("No keyframes found.", self)
+                info("Reusing existing scene detection.", self)
 
-        if self.crf:
-            args.extend(["--crf", str(self.crf)])
+            keyframes = np.load(cache)
+            keyframes_str = "f,".join([str(i) for i in keyframes]) + "f"
 
-        if self.tune is None:
-            self.tune = 3 if "psy" in encoder.lower() else 2
+            if "-c" not in "args":
+                keyframes_file = get_workdir() / "svt_av1_keyframes.cfg"
+                with keyframes_file.open("w", encoding="utf-8") as keyframes_f:
+                    keyframes_f.write(f"ForceKeyFrames : {keyframes_str}\n")
 
-        args.extend(["--tune", str(self.tune)])
+                args.extend(["-c", str(keyframes_file)])
+            else:
+                info("Attempting to use commandline parameter to specify keyframes since `-c` is already used...", self)
+                args.extend(["--force-key-frames", keyframes_str])
 
+            if "--keyint" in args:
+                args[args.index("--keyint") + 1] = "-1"
+            else:
+                args.extend(["--keyint", "-1"])
+
+        # photon_noise
+        if self.photon_noise:
+            if "--fgs-table" not in args and "--film-grain" not in args:
+                fgs_table = get_workdir() / "svt_av1_fgs.tbl"
+                with fgs_table.open("w", encoding="utf-8") as fgs_table_f:
+                    fgs_table_f.write("""filmgrn1
+E 0 18446744073709551615 1 787 1
+	p 3 7 0 8 0 1 128 192 256 128 192 256
+	sY 14 0 4 20 3 39 3 59 3 78 3 98 3 118 3 137 3 157 3 177 4 196 4 216 4 235 4 255 5
+	sCb 0
+	sCr 0
+	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
+	cCb -3 9 -15 20 -6 0 0 9 -22 32 -50 10 -3 1 -15 32 -61 70 -26 -1 -2 17 -40 59 11
+	cCr -3 9 -15 20 -6 0 1 9 -21 32 -50 10 -3 0 -14 31 -61 71 -26 -1 -1 17 -40 58 11
+""")
+
+                args.extend(["--fgs-table", str(fgs_table)])
+
+        # props
         # fmt:off
-        args.extend(self.get_custom_args() + [
+        args.extend([
             "--fps-num", clip_props.get("fps_num"),
             "--fps-denom", clip_props.get("fps_den"),
             "--input-depth", clip_props.get("depth"),
@@ -268,5 +317,6 @@ class SVTAV1(VideoEncoder):
         self.update_process_affinity(process.pid)
         clip.output(process.stdin, y4m=True)
         process.communicate()
+
         tags.update(ENCODER_SETTINGS=self.get_mediainfo_settings(args))
         return VideoFile(output, tags=tags)

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -9,8 +9,15 @@ from vstools import vs
 
 from .encoders.types import Zone
 
-__all__ = ["settings_builder_x265", "settings_builder_x264", "sb", "sb265", "sb264",
-           "settings_builder_5fish_svt_av1_psy", "settings_builder_svt_av1_essential"]
+__all__ = [
+    "settings_builder_x265",
+    "settings_builder_x264",
+    "sb",
+    "sb265",
+    "sb264",
+    "settings_builder_5fish_svt_av1_psy",
+    "settings_builder_svt_av1_essential",
+]
 
 
 def is_full_zone(zone: Zone) -> bool:
@@ -212,56 +219,49 @@ def settings_builder_x264(
 
 
 def settings_builder_5fish_svt_av1_psy(
-    preset: int                     = 2,
-    crf: float                      = 20.00,
-
+    preset: int = 2,
+    crf: float = 20.00,
     # global
-    tune: int | None                = 0,
-    scm: int | None                 = 0,
-    noise_level_thr: int | None     = 16000,
-    chroma_qmc_bias: int | None     = 2,
+    tune: int | None = 0,
+    scm: int | None = 0,
+    noise_level_thr: int | None = 16000,
+    chroma_qmc_bias: int | None = 2,
     texture_preserving_qmc_bias: int | None = None,
-
     # me
-    enable_tf: int | None           = None,
-    kf_tf_strength: int | None      = None,
-    tf_strength: int | None         = None,
-
+    enable_tf: int | None = None,
+    kf_tf_strength: int | None = None,
+    tf_strength: int | None = None,
     # rc
-    balancing_q_bias: int | None    = 1,
+    balancing_q_bias: int | None = 1,
     balancing_luminance_q_bias: float | None = 5.0,
     qp_scale_compress_strength: float | None = None,
-    frame_luma_bias: int | None     = None,
-    noise_level_q_bias: int | None  = None,
+    frame_luma_bias: int | None = None,
+    noise_level_q_bias: int | None = None,
     enable_variance_boost: int | None = None,
     variance_boost_strength: int | None = 1,
-    variance_octile: int | None     = 7,
-    enable_alt_curve: int | None    = None,
-    low_q_taper: int | None         = None,
-
+    variance_octile: int | None = 7,
+    enable_alt_curve: int | None = None,
+    low_q_taper: int | None = None,
     # md & enc_dec
-    qm_min: int | None              = 8,
-    chroma_qm_min: int | None       = 10,
-    qm_max: int | None              = None,
-    chroma_qm_max: int | None       = None,
+    qm_min: int | None = 8,
+    chroma_qm_min: int | None = 10,
+    qm_max: int | None = None,
+    chroma_qm_max: int | None = None,
     noise_norm_strength: int | None = None,
-    ac_bias: float | None           = 1.0,
-    tx_bias: int | None             = None,
-    variance_md_bias: int | None    = 1,
+    ac_bias: float | None = 1.0,
+    tx_bias: int | None = None,
+    variance_md_bias: int | None = 1,
     variance_md_bias_thr: float | None = None,
-    max_32_tx_size: int | None      = None,
-    complex_hvs: int | None         = -1,
-
+    max_32_tx_size: int | None = None,
+    complex_hvs: int | None = -1,
     # dlf & cdef & rest
-    enable_dlf: int | None          = None,
-    dlf_bias: int | None            = 1,
+    enable_dlf: int | None = None,
+    dlf_bias: int | None = 1,
     filtering_noise_detection: int | None = None,
-    enable_cdef: int | None         = None,
-    cdef_bias: int | None           = 1,
-    enable_restoration: int | None  = None,
-    
-    progress: int | None            = 2,
-
+    enable_cdef: int | None = None,
+    cdef_bias: int | None = 1,
+    enable_restoration: int | None = None,
+    progress: int | None = 2,
     **kwargs,
 ):
     """
@@ -312,12 +312,9 @@ def settings_builder_svt_av1_essential(
     quality: str | None = "medium",
     preset: int | None = None,
     crf: int | None = None,
-
     scm: int | None = 0,
     luminance_qp_bias: int | None = 20,
-
     progress: int | None = 3,
-
     **kwargs,
 ):
     """
@@ -341,7 +338,7 @@ def settings_builder_svt_av1_essential(
     settings = settings_builder_svt_av1_essential(...)
     mini = SVTAV1(**settings).encode(final)
     ```
-    
+
     :param speed:           Adjust the speed.
                             `slower` (`--preset 2`) is the recommended starting point. `slow` (`--preset 4`) is faster.
     :param quality:         Adjust the quality.

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -295,7 +295,7 @@ def settings_builder_5fish_svt_av1_psy(
                             SVT-AV1's hierarchical structure is very dynamic, and rate control parameters are very powerful. `--crf` merely marks a starting qindex for rate control. This recommended `--crf` range will differ greatly when different rate control parameters are used.
     """
     args = dict[str, Any]()
-    args["_settings_builder_id"] = "SVT-AV1-PSY v2.3.0-"
+    args["_settings_builder_id"] = r"(?:5fish\/|)SVT-AV1-PSY v2\.3\.0"
 
     for k in inspect.getfullargspec(settings_builder_5fish_svt_av1_psy).args:
         if locals()[k] is not None:

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import cast
+from typing import cast, Any
 import inspect
 
 from muxtools import PathLike, ensure_path, error, warn
@@ -263,7 +263,7 @@ def settings_builder_5fish_svt_av1_psy(
     enable_restoration: int | None = None,
     progress: int | None = 2,
     **kwargs,
-):
+) -> dict[str, Any]:
     """
     This is a settings_builder for 5fish/SVT-AV1-PSY.
     These parameters correspond to `exp` branch of the encoder as of early January 2026.
@@ -294,17 +294,14 @@ def settings_builder_5fish_svt_av1_psy(
                             `15.00 ~ 25.00` is the recommended starting point; About `10.00` until `30.00 ~ 40.00` is the recommended range for 5fish/SVT-AV1-PSY.
                             SVT-AV1's hierarchical structure is very dynamic, and rate control parameters are very powerful. `--crf` merely marks a starting qindex for rate control. This recommended `--crf` range will differ greatly when different rate control parameters are used.
     """
-    args = {}
+    args = dict[str, Any]()
     args["_settings_builder_id"] = "SVT-AV1-PSY v2.3.0-"
 
     for k in inspect.getfullargspec(settings_builder_5fish_svt_av1_psy).args:
         if locals()[k] is not None:
             args[k] = locals()[k]
-    for k, v in kwargs.items():
-        if v is not None:
-            args[k] = v
 
-    return args
+    return args | kwargs
 
 
 def settings_builder_svt_av1_essential(
@@ -316,7 +313,7 @@ def settings_builder_svt_av1_essential(
     luminance_qp_bias: int | None = 20,
     progress: int | None = 3,
     **kwargs,
-):
+) -> dict[str, Any]:
     """
     This is a settings_builder for SVT-AV1-Essential.
     These parameters correspond to v3.1.2-Essential.
@@ -344,15 +341,14 @@ def settings_builder_svt_av1_essential(
     :param quality:         Adjust the quality.
                             `medium` (`--crf 30`) is the recommended starting point. `low` (`--crf 35`), or `lower` (`--crf 40`) is lower.
     """
-    args = {}
+    args = dict[str, Any]()
     args["_settings_builder_id"] = "SVT-AV1-Essential"
 
     for k in inspect.getfullargspec(settings_builder_svt_av1_essential).args:
         if locals()[k] is not None:
             args[k] = locals()[k]
-    for k, v in kwargs.items():
-        if v is not None:
-            args[k] = v
+
+    args = args | kwargs
 
     if "speed" in args and "preset" in args:
         del args["speed"]

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -1,6 +1,7 @@
 import os
 import re
 from typing import cast
+import inspect
 
 from muxtools import PathLike, ensure_path, error, warn
 from jetpytools import CustomValueError
@@ -8,7 +9,8 @@ from vstools import vs
 
 from .encoders.types import Zone
 
-__all__ = ["settings_builder_x265", "settings_builder_x264", "sb", "sb265", "sb264"]
+__all__ = ["settings_builder_x265", "settings_builder_x264", "sb", "sb265", "sb264",
+           "settings_builder_5fish_svt_av1_psy", "settings_builder_svt_av1_essential"]
 
 
 def is_full_zone(zone: Zone) -> bool:
@@ -207,6 +209,165 @@ def settings_builder_x264(
 
     settings += (" " + append.strip()) if append.strip() else ""
     return settings
+
+
+def settings_builder_5fish_svt_av1_psy(
+    preset: int                     = 2,
+    crf: float                      = 20.00,
+
+    # global
+    tune: int | None                = 0,
+    scm: int | None                 = 0,
+    noise_level_thr: int | None     = 16000,
+    chroma_qmc_bias: int | None     = 2,
+    texture_preserving_qmc_bias: int | None = None,
+
+    # me
+    enable_tf: int | None           = None,
+    kf_tf_strength: int | None      = None,
+    tf_strength: int | None         = None,
+
+    # rc
+    balancing_q_bias: int | None    = 1,
+    balancing_luminance_q_bias: float | None = 5.0,
+    qp_scale_compress_strength: float | None = None,
+    frame_luma_bias: int | None     = None,
+    noise_level_q_bias: int | None  = None,
+    enable_variance_boost: int | None = None,
+    variance_boost_strength: int | None = 1,
+    variance_octile: int | None     = 7,
+    enable_alt_curve: int | None    = None,
+    low_q_taper: int | None         = None,
+
+    # md & enc_dec
+    qm_min: int | None              = 8,
+    chroma_qm_min: int | None       = 10,
+    qm_max: int | None              = None,
+    chroma_qm_max: int | None       = None,
+    noise_norm_strength: int | None = None,
+    ac_bias: float | None           = 1.0,
+    tx_bias: int | None             = None,
+    variance_md_bias: int | None    = 1,
+    variance_md_bias_thr: float | None = None,
+    max_32_tx_size: int | None      = None,
+    complex_hvs: int | None         = -1,
+
+    # dlf & cdef & rest
+    enable_dlf: int | None          = None,
+    dlf_bias: int | None            = 1,
+    filtering_noise_detection: int | None = None,
+    enable_cdef: int | None         = None,
+    cdef_bias: int | None           = 1,
+    enable_restoration: int | None  = None,
+    
+    progress: int | None            = 2,
+
+    **kwargs,
+):
+    """
+    This is a settings_builder for 5fish/SVT-AV1-PSY.
+    These parameters correspond to `exp` branch of the encoder as of early January 2026.
+    Repository: https://github.com/5fish/svt-av1-psy
+    Windows build: https://github.com/Akatmks/svt-av1-psy-quality/releases
+    Linux build: `Build/linux/build.sh --native --static --release --enable-lto --enable-pgo`; clang recommended over gcc.
+
+    5fish/SVT-AV1-PSY is better for relatively higher quality AV1 encodes.
+    For encodes targeting tiny filesize, check out `settings_builder_svt_av1_essential`.
+    AV1 encoders in general have a lower quality ceiling. For high fidelity encodes, you should use x265 instead.
+
+    This provides a set of default parameters suitable for encoding clean sources.
+    For clean sources, you should remove all dynamic noise while keeping texture intact, and never regrain before sending to SVT-AV1.
+    For sources with heavy dynamic grain, you can consider using x265 or x264 instead. However, if you still want a mini, you would need to adjust some parameters here.
+
+    For better explanations of parameters, check the `Docs/Parameters.md` file in encoder's GitHub.
+    For how to set the parameters for your source, check the guides section in the AV1 weeb server, specifically “High effort high quality AV1 encode note collection”.
+
+    To use this settings_builder,
+    ```py
+    settings = settings_builder_5fish_svt_av1_psy(...)
+    mini = SVTAV1(**settings, sd_clip=src).encode(final)
+    ```
+
+    :param preset:          Adjust the speed.
+                            `2` is the recommended starting point; `0` or `-1` is the slower options; `4` is the faster option.
+    :param crf:             Adjust the quality.
+                            `15.00 ~ 25.00` is the recommended starting point; About `10.00` until `30.00 ~ 40.00` is the recommended range for 5fish/SVT-AV1-PSY.
+                            SVT-AV1's hierarchical structure is very dynamic, and rate control parameters are very powerful. `--crf` merely marks a starting qindex for rate control. This recommended `--crf` range will differ greatly when different rate control parameters are used.
+    """
+    args = {}
+    args["_settings_builder_id"] = "SVT-AV1-PSY v2.3.0-"
+
+    for k in inspect.getfullargspec(settings_builder_5fish_svt_av1_psy).args:
+        if locals()[k] is not None:
+            args[k] = locals()[k]
+    for k, v in kwargs.items():
+        if v is not None:
+            args[k] = v
+
+    return args
+
+
+def settings_builder_svt_av1_essential(
+    speed: str | None = "slower",
+    quality: str | None = "medium",
+    preset: int | None = None,
+    crf: int | None = None,
+
+    scm: int | None = 0,
+    luminance_qp_bias: int | None = 20,
+
+    progress: int | None = 3,
+
+    **kwargs,
+):
+    """
+    This is a settings_builder for SVT-AV1-Essential.
+    These parameters correspond to v3.1.2-Essential.
+    Repository: https://github.com/nekotrix/SVT-AV1-Essential
+    Windows build: https://github.com/Akatmks/svt-av1-psy-quality/releases
+    Linux build: `Build/linux/build.sh --native --static --release --enable-lto --enable-pgo`; note the available patches; clang recommended over gcc.
+
+    SVT-AV1-Essential is better for mini encodes targeting tiny filesize with `--quality` worse than or equal to `medium`.
+    For higer quality AV1 encodes, check out `settings_builder_5fish_svt_av1_psy`.
+    AV1 encoders in general have a lower quality ceiling. For high fidelity encodes, you should use x265 instead.
+
+    This provides a set of default parameters suitable for encoding clean sources.
+    You should not regrain before sending to SVT-AV1.
+
+    For better explanations of parameters, check the `Docs/Parameters.md` file in encoder's GitHub.
+
+    To use this settings_builder,
+    ```py
+    settings = settings_builder_svt_av1_essential(...)
+    mini = SVTAV1(**settings).encode(final)
+    ```
+    
+    :param speed:           Adjust the speed.
+                            `slower` (`--preset 2`) is the recommended starting point. `slow` (`--preset 4`) is faster.
+    :param quality:         Adjust the quality.
+                            `medium` (`--crf 30`) is the recommended starting point. `low` (`--crf 35`), or `lower` (`--crf 40`) is lower.
+    """
+    args = {}
+    args["_settings_builder_id"] = "SVT-AV1-Essential"
+
+    for k in inspect.getfullargspec(settings_builder_svt_av1_essential).args:
+        if locals()[k] is not None:
+            args[k] = locals()[k]
+    for k, v in kwargs.items():
+        if v is not None:
+            args[k] = v
+
+    if "speed" in args and "preset" in args:
+        del args["speed"]
+    if "quality" in args and "crf" in args:
+        del args["quality"]
+
+    if "speed" not in args and "preset" not in args:
+        raise error("You must specify either speed or preset", settings_builder_svt_av1_essential)
+    if "quality" not in args and "crf" not in args:
+        raise error("You must specify either quality or crf", settings_builder_svt_av1_essential)
+
+    return args
 
 
 sb = settings_builder_x265


### PR DESCRIPTION
Thank you, Vodes!

As previously communicated on Discord:  
* Two new `settings_builder` proving a good default for 5fish/SVT-AV1-PSY and SVT-AV1-Essential respectively.  
  * Docstring is provided to note where to find the forks and when to use which one.  
  * The default parameters used for 5fish/SVT-AV1-PSY includes the latest studies and features, and is a combination of parameters commonly recommended by Itachi Uchiha, me, and various other community members.  
  * The default pararmeter used for SVT-AV1-Essential is from Trix.  
* `SVTAV1` updated.  
  * Previous required `--preset` and `--crf` now made optional due to `--speed` and `--quality` option in SVT-AV1-Essential. But a default will still be set if the user didn't provide anything.  
  * Previous required `--tune` now made optional because the encoder simply evolves too fast. A default can be provided via `settings_builder` so no longer needed here.  
  * A new scene detection optimised for SVT-AV1's hierarchical structure is implemented ~~(copied from [my own script](https://github.com/Akatmks/Akatsumekusa-Encoding-Scripts?tab=readme-ov-file#progressive-scene-detection))~~.  
    A good scene detection optimised for hierarchical structure is required for SVT-AV1 to produce fewer bad frames, and also this, to a degree, reduce the issue of WWXD marking too much scenechanges in challenging sections.  
  * A very light photon noise table is now added by default.  

Regarding further maintainence, I will make pull request occasionally to update the parameters according to latest encoder knowledge and implementation.  

Thank you so much! Let me know if there were any issues.  