### PR TITLE
x265: Add light photon noise via `--aom-film-grain`;  SVTAV1: May update

### DIFF
--- a/vsmuxtools/video/encoders/noise.py
+++ b/vsmuxtools/video/encoders/noise.py
@@ -1,0 +1,92 @@
+import random
+from muxtools import PathLike, ensure_path
+
+__all__ = [
+    "SVTAV1_LIGHT_NOISE_TABLE_FULL",
+    "SVTAV1_LIGHT_NOISE_TABLE_LIMITED",
+    "x265_write_light_noise_table_limited",
+    "x265_write_light_noise_table_full",
+]
+
+SVTAV1_LIGHT_NOISE_TABLE_LIMITED = """filmgrn1
+E 0 18446744073709551615 1 787 1
+	p 3 7 0 8 0 1 128 192 256 128 192 256
+    sY 9 0 0 16 0 17 2 18 3 157 3 177 4 233 4 235 0 255 0
+	sCb 0
+	sCr 0
+	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
+	cCb -3 9 -15 20 -6 0 0 9 -22 32 -50 10 -3 1 -15 32 -61 70 -26 -1 -2 17 -40 59 11
+	cCr -3 9 -15 20 -6 0 1 9 -21 32 -50 10 -3 0 -14 31 -61 71 -26 -1 -1 17 -40 58 11
+"""
+"""
+A table for photon noise that serves as a light dither layer to prevent banding.\n
+With cutoffs for limited range clips.
+"""
+
+SVTAV1_LIGHT_NOISE_TABLE_FULL = """filmgrn1
+E 0 18446744073709551615 1 787 1
+	p 3 7 0 8 0 1 128 192 256 128 192 256
+	sY 6 0 4 20 3 157 3 177 4 235 4 255 5
+	sCb 0
+	sCr 0
+	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
+	cCb -3 9 -15 20 -6 0 0 9 -22 32 -50 10 -3 1 -15 32 -61 70 -26 -1 -2 17 -40 59 11
+	cCr -3 9 -15 20 -6 0 1 9 -21 32 -50 10 -3 0 -14 31 -61 71 -26 -1 -1 17 -40 58 11
+"""
+"""
+A table for photon noise that serves as a light dither layer to prevent banding.\n
+With cutoffs for full range clips.
+"""
+
+
+def x265_write_light_noise_table_helper(target: PathLike, length: int, s: str):
+    # fmt: off
+    seed_pool = [65506, 65501, 65484, 65476, 65466, 65464, 65420, 65417, 65391, 65345, 65333, 65299,
+                65260, 64921, 64917, 64831, 64774, 64693, 64448, 64436, 64435, 64423, 64384, 64332,
+                64285, 64274, 64240, 64189, 64176, 64126, 64113, 64093, 63947, 63647, 63580, 63507,
+                63504, 63456, 63023, 62518, 62359, 62258, 62156, 62143, 62040, 61851, 61692, 61482,
+                61476, 60973, 60878, 60711, 60619, 60584, 60537, 60501, 60123, 59991, 59929, 59846,
+                59724, 59669, 59665, 59637, 59625, 59621, 59180, 59119]
+    # fmt: on
+    seeds = [63504]
+    while len(seeds) < length:
+        n = random.choice(seed_pool)
+        if n not in seeds[-32:]:
+            seeds.append(n)
+
+    with ensure_path(target, None).open("wb") as f:
+        for seed in seeds:
+            f.write((1).to_bytes(4, byteorder="little", signed=True))
+            f.write((seed).to_bytes(2, byteorder="little", signed=False))
+            f.write((1).to_bytes(4, byteorder="little", signed=True))
+
+            for n in s.split():
+                f.write((int(n)).to_bytes(4, byteorder="little", signed=True))
+            f.write((0).to_bytes(4, byteorder="little", signed=True))
+            f.write((0).to_bytes(4, byteorder="little", signed=True))
+            f.write((8).to_bytes(4, byteorder="little", signed=True))
+
+            f.write((3).to_bytes(4, byteorder="little", signed=True))
+            for n in "3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18".split():
+                f.write((int(n)).to_bytes(4, byteorder="little", signed=True))
+            f.write((7).to_bytes(4, byteorder="little", signed=True))
+            f.write((0).to_bytes(4, byteorder="little", signed=True))
+
+            f.write((1).to_bytes(4, byteorder="little", signed=True))
+            f.write((1).to_bytes(4, byteorder="little", signed=True))
+
+
+def x265_write_light_noise_table_limited(target: PathLike, length: int):
+    """
+    A table for photon noise that serves as a light dither layer to prevent banding.\n
+    With cutoffs for limited range clips.
+    """
+    x265_write_light_noise_table_helper(target, length, "9 0 0 16 0 17 2 18 3 157 3 177 4 233 4 235 0 255 0")
+
+
+def x265_write_light_noise_table_full(target: PathLike, length: int):
+    """
+    A table for photon noise that serves as a light dither layer to prevent banding.\n
+    With cutoffs for full range clips.
+    """
+    x265_write_light_noise_table_helper(target, length, "6 0 4 20 3 157 3 177 4 235 4 255 5")

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -86,28 +86,31 @@ class x265(SupportsQP):
     """
     Encodes your clip to an hevc/h265 file using x265.
 
-    :param settings:            This will by default try to look for an `x265_settings` file in your cwd.
-                                If it doesn't find one it will warn you and resort to the default settings_builder preset.
-                                You can either pass settings as usual or a filepath here.
+    :param settings:            This will by default try to look for an `x265_settings` file in your cwd.\n
+                                If it doesn't find one it will warn you and resort to the default settings_builder preset.\n
+                                You can either pass settings as usual or a filepath here.\n
                                 If the filepath doesn't exist it will assume you passed actual settings and pass those to the encoder.
 
-    :param zones:               With this you can tweak settings of specific regions of the video.
-                                In x265 you're basically limited to a flat bitrate multiplier or force QP ("q")
-                                For example (100, 300, "b", 1.2) or [(100, 300, "q", 12), (500, 750, 1.3)]
+    :param zones:               With this you can tweak settings of specific regions of the video.\n
+                                In x265 you're basically limited to a flat bitrate multiplier or force QP ("q")\n
+                                For example (100, 300, "b", 1.2) or [(100, 300, "q", 12), (500, 750, 1.3)]\n
                                 If the third part is not a string it will assume a bitrate multiplier (or "b")
 
     :param qp_file:             Here you can pass a bool to en/disable or an existing filepath for one.
-    :param qp_clip:             Can either be a straight up VideoNode or a SRC_FILE/FileInfo from this package.
+    :param qp_clip:             Can either be a straight up VideoNode or a SRC_FILE/FileInfo from this package.\n
                                 If neither a clip or a file are given it will simply skip.
                                 If only a clip is given it will generate one.
 
-    :param add_props:           This will explicitly add all props taken from the clip to the command line.
-                                This will be disabled by default if you are using a file and otherwise enabled.
+    :param add_props:           This will explicitly add all props taken from the clip to the command line.\n
+                                This will be disabled by default if you are using a file and otherwise enabled.\n
                                 Files can have their own tokens like in vs-encode/vardautomation that will be filled in.
 
-    :param light_photon_noise:  Add a layer of light photon noise on top, serving a similar role as a light regrain / dither.
-                                This feature is supported on mpv but not on a lot of other players, which means it shouldn't replace your main regrain.
-                                Automatically disabled when either `--aom-film-grain` or `--film-grain` is used.
+    :param light_photon_noise:  Add a layer of light photon noise on top, serving a similar role as a light regrain / dither.\n
+                                This feature is supported on mpv but not on a lot of other players, which means it shouldn't replace your main regrain.\n
+                                Automatically disabled when either `--aom-film-grain` or `--film-grain` is used.\n
+                                Do note that x265 will log the path to the file containing the grain pattern so, if for whatever reason that can't be a relative one,
+                                you need to check the mediainfo and make sure it doesn't contain anything sensitive.\n
+                                **This is unlikely to happen if you don't mangle the muxtools workdir yourself.**
 
     :param sar:                 Here you can pass your Pixel / Sample Aspect Ratio. This will overwrite whatever is in the clip if passed.
     :param resumable:           Enable or disable resumable encodes. Very useful for people that have scripts that crash their PC (skill issue tbh)
@@ -145,19 +148,8 @@ class x265(SupportsQP):
                     x265_write_light_noise_table_full(fgs_table, clip.num_frames - start_frame)
                 try:
                     fgs_table = fgs_table.relative_to(Path.cwd())
-                    if (os.name == "nt" and sys.version_info[1] >= 12) or (os.name == "posix" and sys.version_info[1] >= 7):
-                        if Path.cwd().is_mount():
-                            raise ValueError
-                # Although I didn't find the code for it, in the tests it looks like vs-muxtools will always switch cwd to workdir,
-                # so the `relative_to` will always success and this `except` will never trigger, which is nice.
                 except ValueError:
-                    # fmt: off
-                    warn("Due to an oversight in x265, the complete path for the aom film grain table will be logged into the video stream, viewable using tools like MediaInfo.", self)
-                    warn("vs-muxtools by default tries to make the path relative. This way video stream only contains the path from cwd to the film grain table in the workdir.", self)
-                    warn("This warning is displayed either when workdir is not relative to cwd, or your cwd is a mount point.", self)
-                    warn("Right now, this below is the path that will be logged. If this doesn't contain anything sensitive, everything is good. If it does, change your cwd and rerun the encode.", self)
-                    warn(str(fgs_table), self)
-                    # fmt: on
+                    warn(f"The following grain table file path will be visible in the mediainfo:\n{str(fgs_table)}", self)
                 self.update_custom_args(aom_film_grain=str(fgs_table))
 
         if self.settings:

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -140,9 +140,9 @@ class x265(SupportsQP):
             if not any(key in self.get_custom_args_dict() for key in {"aom_film_grain", "film_grain"}):
                 fgs_table = get_workdir() / "x265_grain.bin"
                 if clip_props.get("range") == "limited":
-                    x265_write_light_noise_table_limited(fgs_table, clip.num_frames)
+                    x265_write_light_noise_table_limited(fgs_table, clip.num_frames - start_frame)
                 else:
-                    x265_write_light_noise_table_full(fgs_table, clip.num_frames)
+                    x265_write_light_noise_table_full(fgs_table, clip.num_frames - start_frame)
                 try:
                     fgs_table = fgs_table.relative_to(Path.cwd())
                     if (os.name == "nt" and sys.version_info[1] >= 12) or (os.name == "posix" and sys.version_info[1] >= 7):

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -8,10 +8,13 @@ from muxtools.utils.dataclass import dataclass, allow_extra
 import re
 import json
 import random
+import sys
+import os
 
 from .base import SupportsQP, VideoEncoder
 from .types import LosslessPreset
 from ..settings import shift_zones, zones_to_args, norm_zones
+from ..clip_metadata import props_dict, SVT_AV1_RANGES
 
 from vsmuxtools.utils.source import generate_svt_av1_keyframes, src_file
 
@@ -21,7 +24,7 @@ __all__ = ["x264", "x265", "LosslessX264", "SVTAV1"]
 SVTAV1_LIGHT_NOISE_TABLE_LIMITED = """filmgrn1
 E 0 18446744073709551615 1 787 1
 	p 3 7 0 8 0 1 128 192 256 128 192 256
-    sY 10 0 0 16 0 17 2 18 3 157 3 177 4 233 4 234 2 235 0 255 0
+    sY 9 0 0 16 0 17 2 18 3 157 3 177 4 233 4 235 0 255 0
 	sCb 0
 	sCr 0
 	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
@@ -36,7 +39,7 @@ With cutoffs for limited range clips.
 SVTAV1_LIGHT_NOISE_TABLE_FULL = """filmgrn1
 E 0 18446744073709551615 1 787 1
 	p 3 7 0 8 0 1 128 192 256 128 192 256
-	sY 14 0 4 20 3 39 3 59 3 78 3 98 3 118 3 137 3 157 3 177 4 196 4 216 4 235 4 255 5
+	sY 6 0 4 20 3 157 3 177 4 235 4 255 5
 	sCb 0
 	sCr 0
 	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
@@ -83,10 +86,10 @@ def x265_write_light_noise_table_helper(target: PathLike, length: int, s: str):
             f.write((1).to_bytes(4, byteorder="little", signed=True))
 
 def x265_write_light_noise_table_limited(target: PathLike, length: int):
-    x265_write_light_noise_table_helper(target, legnth, "10 0 0 16 0 17 2 18 3 157 3 177 4 233 4 234 2 235 0 255 0")
+    x265_write_light_noise_table_helper(target, length, "9 0 0 16 0 17 2 18 3 157 3 177 4 233 4 235 0 255 0")
 
 def x265_write_light_noise_table_full(target: PathLike, length: int):
-    x265_write_light_noise_table_helper(target, legnth, "14 0 4 20 3 39 3 59 3 78 3 98 3 118 3 137 3 157 3 177 4 196 4 216 4 235 4 255 5")
+    x265_write_light_noise_table_helper(target, length, "6 0 4 20 3 157 3 177 4 235 4 255 5")
 
 
 @dataclass(config=allow_extra)
@@ -206,6 +209,20 @@ class x265(SupportsQP):
                     x265_write_light_noise_table_limited(fgs_table, clip.num_frames)
                 else:
                     x265_write_light_noise_table_full(fgs_table, clip.num_frames)
+                try:
+                    fgs_table = fgs_table.relative_to(Path.cwd())
+                    if (os.name == "nt" and sys.version_info[1] >= 12) or \
+                       (os.name == "posix" and sys.version_info[1] >= 7):
+                        if Path.cwd().is_mount():
+                            raise ValueError
+                # Although I didn't find the code for it, in the tests it looks like vs-muxtools will always switch cwd to workdir,
+                # so the `relative_to` will always success and this `except` will never trigger, which is nice.
+                except ValueError:
+                    warn("Due to an oversight in x265, the complete path for the aom film grain table will be logged into the video stream, viewable using tools like MediaInfo.", self)
+                    warn("vs-muxtools by default tries to make the path relative. This way video stream only contains the path from cwd to the film grain table in the workdir.", self)
+                    warn("This warning is displayed either when workdir is not relative to cwd, or your cwd is a mount point.", self)
+                    warn("Right now, this below is the path that will be logged. If this doesn't contain anything sensitive, everything is good. If it does, change your cwd and rerun the encode.", self)
+                    warn(str(fgs_table), self)
                 self.update_custom_args(aom_film_grain=str(fgs_table))
         if self.settings:
             args.extend(self.settings if isinstance(self.settings, list) else shlex.split(str(self.settings)))
@@ -316,8 +333,6 @@ class SVTAV1(VideoEncoder):
         elif clip.format.bits_per_sample < 10:
             warn("SVT-AV1 works best at 10 bit.\nClip will be converted to 10 bit", self, 2)
             clip = finalize_clip(clip, 10)
-
-        from vsmuxtools.video.clip_metadata import props_dict, SVT_AV1_RANGES
 
         clip_props = props_dict(clip, False, SVT_AV1_RANGES)
         match int(clip_props["chromaloc"]):

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -7,6 +7,7 @@ from muxtools.utils.env import get_binary_version
 from muxtools.utils.dataclass import dataclass, allow_extra
 import re
 import json
+import random
 
 from .base import SupportsQP, VideoEncoder
 from .types import LosslessPreset
@@ -15,6 +16,77 @@ from ..settings import shift_zones, zones_to_args, norm_zones
 from vsmuxtools.utils.source import generate_svt_av1_keyframes, src_file
 
 __all__ = ["x264", "x265", "LosslessX264", "SVTAV1"]
+
+
+SVTAV1_LIGHT_NOISE_TABLE_LIMITED = """filmgrn1
+E 0 18446744073709551615 1 787 1
+	p 3 7 0 8 0 1 128 192 256 128 192 256
+    sY 10 0 0 16 0 17 2 18 3 157 3 177 4 233 4 234 2 235 0 255 0
+	sCb 0
+	sCr 0
+	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
+	cCb -3 9 -15 20 -6 0 0 9 -22 32 -50 10 -3 1 -15 32 -61 70 -26 -1 -2 17 -40 59 11
+	cCr -3 9 -15 20 -6 0 1 9 -21 32 -50 10 -3 0 -14 31 -61 71 -26 -1 -1 17 -40 58 11
+"""
+"""
+A table for photon noise that serves as a light dither layer to prevent banding.\n
+With cutoffs for limited range clips.
+"""
+
+SVTAV1_LIGHT_NOISE_TABLE_FULL = """filmgrn1
+E 0 18446744073709551615 1 787 1
+	p 3 7 0 8 0 1 128 192 256 128 192 256
+	sY 14 0 4 20 3 39 3 59 3 78 3 98 3 118 3 137 3 157 3 177 4 196 4 216 4 235 4 255 5
+	sCb 0
+	sCr 0
+	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
+	cCb -3 9 -15 20 -6 0 0 9 -22 32 -50 10 -3 1 -15 32 -61 70 -26 -1 -2 17 -40 59 11
+	cCr -3 9 -15 20 -6 0 1 9 -21 32 -50 10 -3 0 -14 31 -61 71 -26 -1 -1 17 -40 58 11
+"""
+"""
+A table for photon noise that serves as a light dither layer to prevent banding.\n
+With cutoffs for full range clips.
+"""
+
+def x265_write_light_noise_table_helper(target: PathLike, length: int, s: str):
+    seed_pool = [65506, 65501, 65484, 65476, 65466, 65464, 65420, 65417, 65391, 65345, 65333, 65299,
+                 65260, 64921, 64917, 64831, 64774, 64693, 64448, 64436, 64435, 64423, 64384, 64332,
+                 64285, 64274, 64240, 64189, 64176, 64126, 64113, 64093, 63947, 63647, 63580, 63507,
+                 63504, 63456, 63023, 62518, 62359, 62258, 62156, 62143, 62040, 61851, 61692, 61482,
+                 61476, 60973, 60878, 60711, 60619, 60584, 60537, 60501, 60123, 59991, 59929, 59846,
+                 59724, 59669, 59665, 59637, 59625, 59621, 59180, 59119]
+    seeds = [63504]
+    while(len(seeds) < length):
+        n = random.choice(seed_pool)
+        if n not in seeds[-32:]:
+            seeds.append(n)
+
+    with target.open("wb") as f:
+        for seed in seeds:
+            f.write((1).to_bytes(4, byteorder="little", signed=True))
+            f.write((seed).to_bytes(2, byteorder="little", signed=False))
+            f.write((1).to_bytes(4, byteorder="little", signed=True))
+        
+            for n in s.split():
+                f.write((int(n)).to_bytes(4, byteorder="little", signed=True))
+            f.write((0).to_bytes(4, byteorder="little", signed=True))
+            f.write((0).to_bytes(4, byteorder="little", signed=True))
+            f.write((8).to_bytes(4, byteorder="little", signed=True))
+        
+            f.write((3).to_bytes(4, byteorder="little", signed=True))
+            for n in "3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18".split():
+                f.write((int(n)).to_bytes(4, byteorder="little", signed=True))
+            f.write((7).to_bytes(4, byteorder="little", signed=True))
+            f.write((0).to_bytes(4, byteorder="little", signed=True))
+        
+            f.write((1).to_bytes(4, byteorder="little", signed=True))
+            f.write((1).to_bytes(4, byteorder="little", signed=True))
+
+def x265_write_light_noise_table_limited(target: PathLike, length: int):
+    x265_write_light_noise_table_helper(target, legnth, "10 0 0 16 0 17 2 18 3 157 3 177 4 233 4 234 2 235 0 255 0")
+
+def x265_write_light_noise_table_full(target: PathLike, length: int):
+    x265_write_light_noise_table_helper(target, legnth, "14 0 4 20 3 39 3 59 3 78 3 98 3 118 3 137 3 157 3 177 4 196 4 216 4 235 4 255 5")
 
 
 @dataclass(config=allow_extra)
@@ -97,6 +169,10 @@ class x265(SupportsQP):
                                 This will be disabled by default if you are using a file and otherwise enabled.
                                 Files can have their own tokens like in vs-encode/vardautomation that will be filled in.
 
+    :param light_photon_noise:  Add a layer of light photon noise on top, serving a similar role as a light regrain / dither.
+                                This feature is supported on mpv but not on a lot of other players, which means it shouldn't replace your main regrain.
+                                Automatically disabled when either `--aom-film-grain` or `--film-grain` is used.
+
     :param sar:                 Here you can pass your Pixel / Sample Aspect Ratio. This will overwrite whatever is in the clip if passed.
     :param resumable:           Enable or disable resumable encodes. Very useful for people that have scripts that crash their PC (skill issue tbh)
     :param csv:                 Either a bool to enable or disable csv logging or a Filepath for said csv.
@@ -105,6 +181,7 @@ class x265(SupportsQP):
     resumable: bool = True
     csv: bool | PathLike = True
     x265 = True
+    light_photon_noise: bool = False
 
     def __post_init__(self):
         self.executable = get_executable("x265")
@@ -112,6 +189,7 @@ class x265(SupportsQP):
 
     def _encode_clip(self, clip: vs.VideoNode, out: Path, qpfile: str | None, start_frame: int = 0) -> Path:
         args = [self.executable, "-o", str(out.resolve())]
+        clip_props = props_dict(clip, False)
         if self.csv:
             if isinstance(self.csv, bool):
                 show_name = get_setup_attr("show_name", "")
@@ -121,6 +199,14 @@ class x265(SupportsQP):
             args.extend(["--csv", str(csv_file)])
         if qpfile:
             args.extend(["--qpfile", qpfile])
+        if self.light_photon_noise:
+            if not any(key in self.get_custom_args_dict() for key in {"aom_film_grain", "film_grain"}):
+                fgs_table = get_workdir() / "x265_grain.bin"
+                if clip_props.get("range") == "limited":
+                    x265_write_light_noise_table_limited(fgs_table, clip.num_frames)
+                else:
+                    x265_write_light_noise_table_full(fgs_table, clip.num_frames)
+                self.update_custom_args(aom_film_grain=str(fgs_table))
         if self.settings:
             args.extend(self.settings if isinstance(self.settings, list) else shlex.split(str(self.settings)))
         if self.zones:
@@ -174,37 +260,6 @@ class LosslessX264(VideoEncoder):
         avc._update_settings(clip, False)
         avc._encode_clip(clip, out, None, 0)
         return VideoFile(out)
-
-
-SVTAV1_LIGHT_NOISE_TABLE_LIMITED = """filmgrn1
-E 0 18446744073709551615 1 787 1
-	p 3 7 0 8 0 1 128 192 256 128 192 256
-    sY 10 0 0 16 0 17 2 18 3 157 3 177 4 233 4 234 2 235 0 255 0
-	sCb 0
-	sCr 0
-	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
-	cCb -3 9 -15 20 -6 0 0 9 -22 32 -50 10 -3 1 -15 32 -61 70 -26 -1 -2 17 -40 59 11
-	cCr -3 9 -15 20 -6 0 1 9 -21 32 -50 10 -3 0 -14 31 -61 71 -26 -1 -1 17 -40 58 11
-"""
-"""
-A table for photon noise that serves as a light dither layer to prevent banding.\n
-With cutoffs for limited range clips.
-"""
-
-SVTAV1_LIGHT_NOISE_TABLE_FULL = """filmgrn1
-E 0 18446744073709551615 1 787 1
-	p 3 7 0 8 0 1 128 192 256 128 192 256
-	sY 14 0 4 20 3 39 3 59 3 78 3 98 3 118 3 137 3 157 3 177 4 196 4 216 4 235 4 255 5
-	sCb 0
-	sCr 0
-	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
-	cCb -3 9 -15 20 -6 0 0 9 -22 32 -50 10 -3 1 -15 32 -61 70 -26 -1 -2 17 -40 59 11
-	cCr -3 9 -15 20 -6 0 1 9 -21 32 -50 10 -3 0 -14 31 -61 71 -26 -1 -1 17 -40 58 11
-"""
-"""
-A table for photon noise that serves as a light dither layer to prevent banding.\n
-With cutoffs for full range clips.
-"""
 
 
 @dataclass(config=allow_extra)

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -7,8 +7,6 @@ from muxtools.utils.env import get_binary_version
 from muxtools.utils.dataclass import dataclass, allow_extra
 import re
 import json
-import sys
-import os
 from .base import SupportsQP, VideoEncoder
 from .types import LosslessPreset
 from .noise import (

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -7,89 +7,22 @@ from muxtools.utils.env import get_binary_version
 from muxtools.utils.dataclass import dataclass, allow_extra
 import re
 import json
-import random
 import sys
 import os
-
 from .base import SupportsQP, VideoEncoder
 from .types import LosslessPreset
+from .noise import (
+    SVTAV1_LIGHT_NOISE_TABLE_FULL,
+    SVTAV1_LIGHT_NOISE_TABLE_LIMITED,
+    x265_write_light_noise_table_full,
+    x265_write_light_noise_table_limited,
+)
 from ..settings import shift_zones, zones_to_args, norm_zones
 from ..clip_metadata import props_dict, SVT_AV1_RANGES
 
 from vsmuxtools.utils.source import generate_svt_av1_keyframes, src_file
 
 __all__ = ["x264", "x265", "LosslessX264", "SVTAV1"]
-
-
-SVTAV1_LIGHT_NOISE_TABLE_LIMITED = """filmgrn1
-E 0 18446744073709551615 1 787 1
-	p 3 7 0 8 0 1 128 192 256 128 192 256
-    sY 9 0 0 16 0 17 2 18 3 157 3 177 4 233 4 235 0 255 0
-	sCb 0
-	sCr 0
-	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
-	cCb -3 9 -15 20 -6 0 0 9 -22 32 -50 10 -3 1 -15 32 -61 70 -26 -1 -2 17 -40 59 11
-	cCr -3 9 -15 20 -6 0 1 9 -21 32 -50 10 -3 0 -14 31 -61 71 -26 -1 -1 17 -40 58 11
-"""
-"""
-A table for photon noise that serves as a light dither layer to prevent banding.\n
-With cutoffs for limited range clips.
-"""
-
-SVTAV1_LIGHT_NOISE_TABLE_FULL = """filmgrn1
-E 0 18446744073709551615 1 787 1
-	p 3 7 0 8 0 1 128 192 256 128 192 256
-	sY 6 0 4 20 3 157 3 177 4 235 4 255 5
-	sCb 0
-	sCr 0
-	cY 3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18
-	cCb -3 9 -15 20 -6 0 0 9 -22 32 -50 10 -3 1 -15 32 -61 70 -26 -1 -2 17 -40 59 11
-	cCr -3 9 -15 20 -6 0 1 9 -21 32 -50 10 -3 0 -14 31 -61 71 -26 -1 -1 17 -40 58 11
-"""
-"""
-A table for photon noise that serves as a light dither layer to prevent banding.\n
-With cutoffs for full range clips.
-"""
-
-def x265_write_light_noise_table_helper(target: PathLike, length: int, s: str):
-    seed_pool = [65506, 65501, 65484, 65476, 65466, 65464, 65420, 65417, 65391, 65345, 65333, 65299,
-                 65260, 64921, 64917, 64831, 64774, 64693, 64448, 64436, 64435, 64423, 64384, 64332,
-                 64285, 64274, 64240, 64189, 64176, 64126, 64113, 64093, 63947, 63647, 63580, 63507,
-                 63504, 63456, 63023, 62518, 62359, 62258, 62156, 62143, 62040, 61851, 61692, 61482,
-                 61476, 60973, 60878, 60711, 60619, 60584, 60537, 60501, 60123, 59991, 59929, 59846,
-                 59724, 59669, 59665, 59637, 59625, 59621, 59180, 59119]
-    seeds = [63504]
-    while(len(seeds) < length):
-        n = random.choice(seed_pool)
-        if n not in seeds[-32:]:
-            seeds.append(n)
-
-    with target.open("wb") as f:
-        for seed in seeds:
-            f.write((1).to_bytes(4, byteorder="little", signed=True))
-            f.write((seed).to_bytes(2, byteorder="little", signed=False))
-            f.write((1).to_bytes(4, byteorder="little", signed=True))
-        
-            for n in s.split():
-                f.write((int(n)).to_bytes(4, byteorder="little", signed=True))
-            f.write((0).to_bytes(4, byteorder="little", signed=True))
-            f.write((0).to_bytes(4, byteorder="little", signed=True))
-            f.write((8).to_bytes(4, byteorder="little", signed=True))
-        
-            f.write((3).to_bytes(4, byteorder="little", signed=True))
-            for n in "3 4 3 3 3 3 3 3 4 2 0 2 3 3 3 2 -7 -19 -4 1 3 2 0 -18".split():
-                f.write((int(n)).to_bytes(4, byteorder="little", signed=True))
-            f.write((7).to_bytes(4, byteorder="little", signed=True))
-            f.write((0).to_bytes(4, byteorder="little", signed=True))
-        
-            f.write((1).to_bytes(4, byteorder="little", signed=True))
-            f.write((1).to_bytes(4, byteorder="little", signed=True))
-
-def x265_write_light_noise_table_limited(target: PathLike, length: int):
-    x265_write_light_noise_table_helper(target, length, "9 0 0 16 0 17 2 18 3 157 3 177 4 233 4 235 0 255 0")
-
-def x265_write_light_noise_table_full(target: PathLike, length: int):
-    x265_write_light_noise_table_helper(target, length, "6 0 4 20 3 157 3 177 4 235 4 255 5")
 
 
 @dataclass(config=allow_extra)
@@ -202,6 +135,7 @@ class x265(SupportsQP):
             args.extend(["--csv", str(csv_file)])
         if qpfile:
             args.extend(["--qpfile", qpfile])
+
         if self.light_photon_noise:
             if not any(key in self.get_custom_args_dict() for key in {"aom_film_grain", "film_grain"}):
                 fgs_table = get_workdir() / "x265_grain.bin"
@@ -211,19 +145,21 @@ class x265(SupportsQP):
                     x265_write_light_noise_table_full(fgs_table, clip.num_frames)
                 try:
                     fgs_table = fgs_table.relative_to(Path.cwd())
-                    if (os.name == "nt" and sys.version_info[1] >= 12) or \
-                       (os.name == "posix" and sys.version_info[1] >= 7):
+                    if (os.name == "nt" and sys.version_info[1] >= 12) or (os.name == "posix" and sys.version_info[1] >= 7):
                         if Path.cwd().is_mount():
                             raise ValueError
                 # Although I didn't find the code for it, in the tests it looks like vs-muxtools will always switch cwd to workdir,
                 # so the `relative_to` will always success and this `except` will never trigger, which is nice.
                 except ValueError:
+                    # fmt: off
                     warn("Due to an oversight in x265, the complete path for the aom film grain table will be logged into the video stream, viewable using tools like MediaInfo.", self)
                     warn("vs-muxtools by default tries to make the path relative. This way video stream only contains the path from cwd to the film grain table in the workdir.", self)
                     warn("This warning is displayed either when workdir is not relative to cwd, or your cwd is a mount point.", self)
                     warn("Right now, this below is the path that will be logged. If this doesn't contain anything sensitive, everything is good. If it does, change your cwd and rerun the encode.", self)
                     warn(str(fgs_table), self)
+                    # fmt: on
                 self.update_custom_args(aom_film_grain=str(fgs_table))
+
         if self.settings:
             args.extend(self.settings if isinstance(self.settings, list) else shlex.split(str(self.settings)))
         if self.zones:
@@ -320,11 +256,7 @@ class SVTAV1(VideoEncoder):
                 warn(f"Encoder version expected by the settings_builder: {self._settings_builder_id}.", self, 2)
 
         if not self.sd_clip and not self._encoder_id.startswith("SVT-AV1-Essential") and "_c" not in self.get_custom_args_dict():
-            warn(
-                "Providing a clip or a file for scene detection is recommended for SVT-AV1.",
-                self,
-                2,
-            )
+            warn("Providing a clip or a file for scene detection is recommended for SVT-AV1.", self, 2)
 
     def encode(self, clip: vs.VideoNode, outfile: PathLike | None = None) -> VideoFile:
         if clip.format.bits_per_sample > 10:

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -228,7 +228,7 @@ def settings_builder_5fish_svt_av1_psy(
 ) -> dict[str, Any]:
     """
     This is a settings_builder for 5fish/SVT-AV1-PSY.
-    These parameters correspond to late April 2026 version of the encoder.
+    These parameters correspond to late May 2026 version of the encoder.
 
     Repository: https://github.com/5fish/svt-av1-psy .
     Windows build: https://github.com/Akatmks/svt-av1-psy-quality/releases .

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -228,7 +228,7 @@ def settings_builder_5fish_svt_av1_psy(
 ) -> dict[str, Any]:
     """
     This is a settings_builder for 5fish/SVT-AV1-PSY.
-    These parameters correspond to mid March 2026 version of the encoder.
+    These parameters correspond to late April 2026 version of the encoder.
 
     Repository: https://github.com/5fish/svt-av1-psy .
     Windows build: https://github.com/Akatmks/svt-av1-psy-quality/releases .
@@ -284,12 +284,6 @@ def settings_builder_svt_av1_essential(
     preset: int | None = None,
     crf: int | None = None,
     scm: int | None = 0,
-    luminance_qp_bias: int | None = 50,
-    enable_tf: int | None = 2,
-    tune: int | None = 0,
-    ac_bias: float | None = 0.7,
-    noise_adaptive_filtering: int | None = 0,
-    enable_dlf: int | None = 3,
     progress: int | None = 3,
     **kwargs,
 ) -> dict[str, Any]:

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -283,14 +283,19 @@ def settings_builder_svt_av1_essential(
     quality: str | None = "medium",
     preset: int | None = None,
     crf: int | None = None,
-    luminance_qp_bias: int | None = 20,
     scm: int | None = 0,
+    luminance_qp_bias: int | None = 50,
+    enable_tf: int | None = 2,
+    tune: int | None = 0,
+    ac_bias: float | None = 0.7,
+    noise_adaptive_filtering: int | None = 0,
+    enable_dlf: int | None = 3,
     progress: int | None = 3,
     **kwargs,
 ) -> dict[str, Any]:
     """
     This is a settings_builder for SVT-AV1-Essential.
-    These parameters correspond to v3.1.2-Essential.
+    These parameters correspond to v4.0.1-Essential.
 
     Repository: https://github.com/nekotrix/SVT-AV1-Essential .
     Windows build: https://github.com/Akatmks/svt-av1-psy-quality/releases .


### PR DESCRIPTION
* Added the same light photon noise as used in `SVTAV1` to `x265`.  
  It should be fairly safe and very useful.  
* Apparently Trix never got around to do updates on SVT-AV1-Essential v4 so here we go.  

~~I haven't tested with the changes or confirmed with Trix yet. Please give me some time.~~  
Thank you so much!  