### PR TITLE
SVTAV1: add resumable encode support

### DIFF
--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -2,7 +2,7 @@ import shlex
 import subprocess
 from vstools import finalize_clip, vs, ChromaLocation
 from pathlib import Path
-from muxtools import get_executable, VideoFile, PathLike, make_output, warn, get_setup_attr, ensure_path, info, get_workdir, error
+from muxtools import get_executable, VideoFile, PathLike, make_output, warn, get_setup_attr, ensure_path, info, debug, get_workdir, error
 from muxtools.utils.env import get_binary_version
 from muxtools.utils.dataclass import dataclass, allow_extra
 import re
@@ -255,20 +255,21 @@ class SVTAV1(VideoEncoder):
                 warn(f"Encoder version expected by the settings_builder: {self._settings_builder_id}.", self, 2)
 
         if self.resumable:
-            mkvextract_ver_str = get_binary_version(get_executable("mkvextract"), r"mkvextract v([0-9.]+)", ["--version"])
-            if not mkvextract_ver_str:
-                raise error("Couldn't parse mkvextract version. v96.0 or newer is required for resumable AV1 encodes.", self)
-
-            try:
-                mkvextract_ver = tuple(map(int, mkvextract_ver_str.split('.')))
-            except ValueError:
-                raise error(f"Couldn't parse mkvextract version v'{mkvextract_ver_str}'. v96.0 or newer is required for resumable AV1 encodes.", self)
-                
-            if mkvextract_ver < (96, 0):
-                raise error(f"mkvextract v{mkvextract_ver_str} detected. v96.0 or newer is required for resumable AV1 encodes.", self)
+            self._check_mkvextract_version()
 
         if not self.sd_clip and not self._encoder_id.startswith("SVT-AV1-Essential") and "_c" not in self.get_custom_args_dict():
             warn("Providing a clip or a file for scene detection is recommended for SVT-AV1.", self, 2)
+
+    def _check_mkvextract_version(self) -> None:
+        mkvextract_ver = get_binary_version(get_executable("mkvextract"), r"mkvextract v([0-9.]+)", ["--version"])
+        if not mkvextract_ver:
+            raise error("Couldn't parse mkvextract version. v96.0 or newer is required for resumable AV1 encodes.", self)
+
+        try:
+            if tuple(map(int, mkvextract_ver.split('.'))) < (96, 0):
+                raise error(f"mkvextract v{mkvextract_ver} detected. v96.0 or newer is required for resumable AV1 encodes.", self)
+        except ValueError:
+            raise error(f"Couldn't parse mkvextract version v'{mkvextract_ver}'. v96.0 or newer is required for resumable AV1 encodes.", self)
 
     def encode(self, clip: vs.VideoNode, outfile: PathLike | None = None) -> VideoFile:
         if clip.format.bits_per_sample > 10:
@@ -409,7 +410,7 @@ class SVTAV1(VideoEncoder):
         # ensure parent folder exists, encoder will output to unexpected location otherwise
         parent_dir = fout.parent.resolve()
         if not parent_dir.exists():
-            info(f"Creating output directory: '{parent_dir}'", self)
+            debug(f"Creating output directory: '{parent_dir}'", self)
             parent_dir.mkdir(parents=True, exist_ok=True)
 
         # user parameters

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -266,7 +266,7 @@ class SVTAV1(VideoEncoder):
             raise error("Couldn't parse mkvextract version. v96.0 or newer is required for resumable AV1 encodes.", self)
 
         try:
-            if tuple(map(int, mkvextract_ver.split('.'))) < (96, 0):
+            if tuple(map(int, mkvextract_ver.split("."))) < (96, 0):
                 raise error(f"mkvextract v{mkvextract_ver} detected. v96.0 or newer is required for resumable AV1 encodes.", self)
         except ValueError:
             raise error("Couldn't parse mkvextract version. v96.0 or newer is required for resumable AV1 encodes.", self)

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -226,12 +226,16 @@ class SVTAV1(VideoEncoder):
                                Automatically disabled when either `--film-grain`, `--fgs-table`, or `--photon-noise` are used.
     :param resumable:          Enable or disable resumable encodes.
     :param quiet_merging:      Suppress the mkvmerge output when combining chunks.
+    :param force_webm:         Force WebM output (only applies to SVT-AV1-Essential v4.0.1+).
+                               When disabled, the format is chosen based on the output filename, allowing you to output to IVF.
+                               Has no effect on other forks.
     """
 
     sd_clip: vs.VideoNode | src_file | None = None
     light_photon_noise: bool = True
     resumable: bool = True
     quiet_merging: bool = True
+    force_webm: bool = True
     _encoder_id: str | None = None
     _settings_builder_id: str | None = None
 
@@ -271,6 +275,17 @@ class SVTAV1(VideoEncoder):
                 raise error("AV1 only supports LEFT and TOPLEFT chroma locations!", self)
 
         output = make_output("svtav1", ext="ivf", user_passed=outfile)
+
+        if "Essential" in self._encoder_id:
+            version_match = re.search(r"(\d+)\.(\d+)\.(\d+)", self._encoder_id)
+            if version_match and tuple(map(int, version_match.groups())) >= (4, 0, 1):
+                if output.suffix.lower() == ".ivf":
+                    if self.force_webm:
+                        warn("SVT-AV1-Essential v4.0.1+ forces WebM output by default. Changing output extension to .webm.", self)
+                        output = output.with_suffix(".webm")
+                    else:
+                        info("Forcing IVF output. No encoder metadata will be written.", self)
+                        self.update_custom_args(webm=0)
 
         if not any(key in self.get_custom_args_dict() for key in {"preset", "speed"}):
             self.update_custom_args(preset=2)
@@ -376,6 +391,12 @@ class SVTAV1(VideoEncoder):
         tags = dict[str, str](ENCODER=str(self._encoder_id))
         args = [self.executable, "--input", "-", "--output", str(fout)]
 
+        # ensure parent folder exists, encoder will output to unexpected location otherwise
+        parent_dir = fout.parent.resolve()
+        if not parent_dir.exists():
+            info(f"Creating output directory: '{parent_dir}'", self)
+            parent_dir.mkdir(parents=True, exist_ok=True)
+
         # user parameters
         args.extend(self.get_custom_args())
 
@@ -401,7 +422,7 @@ class SVTAV1(VideoEncoder):
 
         tags.update(ENCODER_SETTINGS=self.get_mediainfo_settings(args))
 
-        if self.resumable and parts:
+        if self.resumable:
             info("Remuxing and merging parts...")
             merge_parts(fout, output, part_keyframes, parts, self.quiet_merging)
             return VideoFile(output, tags=tags)

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -269,7 +269,7 @@ class SVTAV1(VideoEncoder):
             if tuple(map(int, mkvextract_ver.split('.'))) < (96, 0):
                 raise error(f"mkvextract v{mkvextract_ver} detected. v96.0 or newer is required for resumable AV1 encodes.", self)
         except ValueError:
-            raise error(f"Couldn't parse mkvextract version v'{mkvextract_ver}'. v96.0 or newer is required for resumable AV1 encodes.", self)
+            raise error("Couldn't parse mkvextract version. v96.0 or newer is required for resumable AV1 encodes.", self)
 
     def encode(self, clip: vs.VideoNode, outfile: PathLike | None = None) -> VideoFile:
         if clip.format.bits_per_sample > 10:
@@ -289,10 +289,10 @@ class SVTAV1(VideoEncoder):
                 raise error("AV1 only supports LEFT and TOPLEFT chroma locations!", self)
 
         ext = "ivf"
-        if "Essential" in self._encoder_id:
+        if self._encoder_id is not None and "Essential" in self._encoder_id:
             version_match = re.search(r"(\d+)\.(\d+)\.(\d+)", self._encoder_id)
             if version_match and tuple(map(int, version_match.groups())) >= (4, 0, 1):
-                if not outfile.lower().endswith(".ivf"):
+                if outfile is not None and not str(outfile).lower().endswith(".ivf"):
                     ext = "webm"
                 elif self.force_webm:
                     warn("SVT-AV1-Essential v4.0.1+ forces WebM output by default. Changing output extension to '.webm'.", self)

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -17,6 +17,7 @@ from .noise import (
 )
 from ..settings import shift_zones, zones_to_args, norm_zones
 from ..clip_metadata import props_dict, SVT_AV1_RANGES
+from ..resumable import merge_parts, parse_keyframes
 
 from vsmuxtools.utils.source import generate_svt_av1_keyframes, src_file
 
@@ -223,10 +224,14 @@ class SVTAV1(VideoEncoder):
                                For a layer of noise with different strength or coarseness, you can generate it yourself following the guide available in AV1 weeb server.
                                On supported forks, you may also use `--photon-noise` parameter to apply a basic photon noise with configurable strength but not coarseness.
                                Automatically disabled when either `--film-grain`, `--fgs-table`, or `--photon-noise` are used.
+    :param resumable:          Enable or disable resumable encodes.
+    :param quiet_merging:      Suppress the mkvmerge output when combining chunks.
     """
 
     sd_clip: vs.VideoNode | src_file | None = None
     light_photon_noise: bool = True
+    resumable: bool = True
+    quiet_merging: bool = True
     _encoder_id: str | None = None
     _settings_builder_id: str | None = None
 
@@ -267,15 +272,13 @@ class SVTAV1(VideoEncoder):
 
         output = make_output("svtav1", ext="ivf", user_passed=outfile)
 
-        tags = dict[str, str](ENCODER=str(self._encoder_id))
-        args = [self.executable, "--input", "-", "--output", str(output)]
-
         if not any(key in self.get_custom_args_dict() for key in {"preset", "speed"}):
             self.update_custom_args(preset=2)
         if not any(key in self.get_custom_args_dict() for key in {"crf", "quality", "qp", "rc"}):
             self.update_custom_args(crf=22)
 
         # sd_clip
+        sd_keyframes = None
         if self.sd_clip:
             if "force_key_frames" in self.get_custom_args_dict():
                 raise error("Scene detection from `sd_clip` can't be applied when `--force-key-frames` encoder parameter is already specified.", self)
@@ -303,21 +306,51 @@ class SVTAV1(VideoEncoder):
                 assert all(isinstance(f, int) for f in cache_config["scenecuts"])
 
                 info("Reusing existing scene detection.", self)
-                keyframes = cache_config["scenecuts"]
+                sd_keyframes = cache_config["scenecuts"]
             except Exception:
                 info("Performing scene detection...", self)
-                keyframes = generate_svt_av1_keyframes(sd_clip)
+                sd_keyframes = generate_svt_av1_keyframes(sd_clip)
 
                 cache_config = {
                     "frames": sd_clip.num_frames,
-                    "scenecuts": keyframes,
+                    "scenecuts": sd_keyframes,
                 }
                 with cache.open("w") as cache_f:
                     json.dump(cache_config, cache_f)
 
                 info("Scene detection complete.", self)
 
-            keyframes_str = "f,".join([str(i) for i in keyframes]) + "f"
+        start_frame = 0
+        parts = []
+        part_keyframes = []
+
+        if not self.resumable:
+            fout = output
+        else:
+            pattern = output.with_stem(output.stem + "_part_???")
+            parts = sorted(pattern.parent.glob(pattern.name))
+            info(f"Found {len(parts)} part{'s' if len(parts) != 1 else ''} for this encode")
+
+            for i, p in enumerate(parts):
+                try:
+                    info(f"Parsing keyframes for part {i}...")
+                    kf = parse_keyframes(p)[-1]
+                    if kf == 0:
+                        del parts[-1]
+                    else:
+                        part_keyframes.append(kf)
+                except:
+                    del parts[-1]
+
+            fout = output.with_stem(output.stem + f"_part_{len(parts):03.0f}")
+            start_frame = sum(part_keyframes)
+            info(f"Starting encode at frame {start_frame}")
+            clip = clip[start_frame:]
+
+        if sd_keyframes is not None:
+            adjusted_sd_keyframes = [0] + [k - start_frame for k in sd_keyframes if k > start_frame]
+            keyframes_str = "f,".join([str(i) for i in adjusted_sd_keyframes]) + "f"
+
             if "_c" not in self.get_custom_args_dict():
                 keyframes_file = get_workdir() / "svt_av1_keyframes.cfg"
                 with keyframes_file.open("w", encoding="utf-8") as keyframes_f:
@@ -339,6 +372,9 @@ class SVTAV1(VideoEncoder):
                         fgs_table_f.write(SVTAV1_LIGHT_NOISE_TABLE_FULL)
 
                 self.update_custom_args(fgs_table=str(fgs_table))
+
+        tags = dict[str, str](ENCODER=str(self._encoder_id))
+        args = [self.executable, "--input", "-", "--output", str(fout)]
 
         # user parameters
         args.extend(self.get_custom_args())
@@ -364,4 +400,10 @@ class SVTAV1(VideoEncoder):
         process.communicate()
 
         tags.update(ENCODER_SETTINGS=self.get_mediainfo_settings(args))
-        return VideoFile(output, tags=tags)
+
+        if self.resumable and parts:
+            info("Remuxing and merging parts...")
+            merge_parts(fout, output, part_keyframes, parts, self.quiet_merging)
+            return VideoFile(output, tags=tags)
+
+        return VideoFile(fout, tags=tags)

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -254,6 +254,19 @@ class SVTAV1(VideoEncoder):
                 warn(f"Unexpected encoder version: {self._encoder_id}.", self)
                 warn(f"Encoder version expected by the settings_builder: {self._settings_builder_id}.", self, 2)
 
+        if self.resumable:
+            mkvextract_ver_str = get_binary_version(get_executable("mkvextract"), r"mkvextract v([0-9.]+)", ["--version"])
+            if not mkvextract_ver_str:
+                raise error("Couldn't parse mkvextract version. v96.0 or newer is required for resumable AV1 encodes.", self)
+
+            try:
+                mkvextract_ver = tuple(map(int, mkvextract_ver_str.split('.')))
+            except ValueError:
+                raise error(f"Couldn't parse mkvextract version v'{mkvextract_ver_str}'. v96.0 or newer is required for resumable AV1 encodes.", self)
+                
+            if mkvextract_ver < (96, 0):
+                raise error(f"mkvextract v{mkvextract_ver_str} detected. v96.0 or newer is required for resumable AV1 encodes.", self)
+
         if not self.sd_clip and not self._encoder_id.startswith("SVT-AV1-Essential") and "_c" not in self.get_custom_args_dict():
             warn("Providing a clip or a file for scene detection is recommended for SVT-AV1.", self, 2)
 

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -274,18 +274,20 @@ class SVTAV1(VideoEncoder):
             case _:
                 raise error("AV1 only supports LEFT and TOPLEFT chroma locations!", self)
 
-        output = make_output("svtav1", ext="ivf", user_passed=outfile)
-
+        ext = "ivf"
         if "Essential" in self._encoder_id:
             version_match = re.search(r"(\d+)\.(\d+)\.(\d+)", self._encoder_id)
             if version_match and tuple(map(int, version_match.groups())) >= (4, 0, 1):
-                if output.suffix.lower() == ".ivf":
-                    if self.force_webm:
-                        warn("SVT-AV1-Essential v4.0.1+ forces WebM output by default. Changing output extension to .webm.", self)
-                        output = output.with_suffix(".webm")
-                    else:
-                        info("Forcing IVF output. No encoder metadata will be written.", self)
-                        self.update_custom_args(webm=0)
+                if not outfile.lower().endswith(".ivf"):
+                    ext = "webm"
+                elif self.force_webm:
+                    warn("SVT-AV1-Essential v4.0.1+ forces WebM output by default. Changing output extension to '.webm'.", self)
+                    ext = "webm"
+                else:
+                    warn("Outputting to IVF. No encoder metadata will be written.", self)
+                    self.update_custom_args(webm=0)
+
+        output = make_output("svtav1", ext=ext, user_passed=outfile)
 
         if not any(key in self.get_custom_args_dict() for key in {"preset", "speed"}):
             self.update_custom_args(preset=2)

--- a/vsmuxtools/video/resumable.py
+++ b/vsmuxtools/video/resumable.py
@@ -66,9 +66,13 @@ def merge_parts(last: Path, original_out: Path, keyframes: list[int], parts: lis
     mkv_parts.append(last_mkv)
     _to_delete.update([last_mkv, last])
 
-    out_mkv = original_out.with_suffix(".mkv").resolve()
+    if original_out.suffix.lower() == ".webm":
+        out_mkv = original_out.resolve()
+        args = [mkvmerge, "--webm", "-o", str(out_mkv)]
+    else:
+        out_mkv = original_out.with_suffix(".mkv").resolve()
+        args = [mkvmerge, "-o", str(out_mkv)]
 
-    args = [mkvmerge, "-o", str(out_mkv)]
     first = True
     for part in mkv_parts:
         if not first:
@@ -79,12 +83,16 @@ def merge_parts(last: Path, original_out: Path, keyframes: list[int], parts: lis
     if run_commandline(args, quiet) > 1:
         raise error("Failed to remux last part", merge_parts)
 
-    info("Extracting merged part...")
-    args = [mkvextract, str(out_mkv), "tracks", f"0:{str(original_out.resolve())}"]
-    if run_commandline(args, quiet) > 1:
-        raise error("Failed to extract merged track!", merge_parts)
-
-    _to_delete.add(out_mkv)
+    if original_out.suffix.lower() == ".mkv":
+        info("Merged encode parts successfully. Final output will remain muxed as MKV.")
+    elif original_out.suffix.lower() == ".webm":
+        info("Merged encode parts successfully. Final output will remain muxed as WebM.")
+    else:
+        info("Extracting merged part...")
+        args = [mkvextract, str(out_mkv), "tracks", f"0:{str(original_out.resolve())}"]
+        if run_commandline(args, quiet) > 1:
+            raise error("Failed to extract merged track!", merge_parts)
+        _to_delete.add(out_mkv)
 
     for f in _to_delete:
         f.unlink(True)


### PR DESCRIPTION
Add support for resumable encodes to the AV1 encoders.

I've tested this with the latest versions of both 5fish and Essential, and it works identically to the resume feature in x264 and x265.

One thing that had to be specially considered was sd_clip. This implementation keeps `svt_av1_scene_detection_cache.json` identical if the sd_clip is the same. Meanwhile, `svt_av1_keyframes.cfg` is updated when encoding a new part, with each keyframe being offset by the new start point.

This PR does commit the sin of reusing code from the `SupportsQP` class. One way this could be addressed is by spinning off the reused lines (`pattern = out.with_stem(...` to `info(f"Starting encode...`) into a helper function under `resumable.py`. I can update the PR to do so if desired.