### PR TITLE
SVTAV1: July update

### DIFF
--- a/vsmuxtools/utils/source.py
+++ b/vsmuxtools/utils/source.py
@@ -494,7 +494,7 @@ def generate_svt_av1_keyframes(
     start_frame: int = 0,
     min_scene_length: int = 129,
     min_still_scene_length: int = 193,
-    max_scene_length: int = 257,
+    max_scene_length: int = 321,
 ) -> list[int]:
     """
     Run `generate_keyframes`, and then filter the WWXD keyframe result for SVT-AV1 derived encoders.

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -15,7 +15,9 @@ __all__ = [
     "sb",
     "sb265",
     "sb264",
-    "settings_builder_5fish_svt_av1_psy",
+    "settings_builder_5fish_svt_av1_high_quality",
+    "settings_builder_5fish_svt_av1_mini",
+    "settings_builder_5fish_svt_av1_mini_high_dlf",
     "settings_builder_svt_av1_essential",
 ]
 
@@ -218,60 +220,106 @@ def settings_builder_x264(
     return settings
 
 
-def settings_builder_5fish_svt_av1_psy(
+def settings_builder_5fish_svt_av1_high_quality(
+    preset: int = 0,
+    crf: float = 13.00,
+    lineart_psy_bias: int = 5,
+    texture_psy_bias: int = 4,
+    satd_bias: float | None = 0.50,
+    progress: int | None = 2,
+    **kwargs,
+) -> dict[str, Any]:
+    """
+    This is a settings_builder for 5fish/SVT-AV1.
+    These parameters correspond to early July 2026 version of the encoder.
+
+    Source Repository & Builds: https://github.com/5fish/svt-av1 .
+
+    This settings_builder uses `--preset 0`. If it is too slow, you can switch to `--preset 2` without losing much quality.
+
+    If you want to adjust the parameters for your source, check the Usage section in `README.md` in encoder's GitHub repository.
+
+    To use this settings_builder,
+    ```py
+    settings = settings_builder_5fish_svt_av1_high_quality()
+    mini = SVTAV1(**settings, sd_clip=src).encode(final)
+    ```
+    """
+    args = dict[str, Any]()
+    args["_settings_builder_id"] = r"SVT-AV1 \[5fish"
+
+    for k in inspect.getfullargspec(settings_builder_5fish_svt_av1_high_quality).args:
+        if locals()[k] is not None:
+            args[k] = locals()[k]
+
+    return args | kwargs
+
+def settings_builder_5fish_svt_av1_mini(
     preset: int = 2,
-    crf: float = 20.00,
+    crf: float = 24.00,
     lineart_psy_bias: int = 3,
     texture_psy_bias: int = 3,
     progress: int | None = 2,
     **kwargs,
 ) -> dict[str, Any]:
     """
-    This is a settings_builder for 5fish/SVT-AV1-PSY.
-    These parameters correspond to late May 2026 version of the encoder.
+    This is a settings_builder for 5fish/SVT-AV1.
+    These parameters correspond to early July 2026 version of the encoder.
 
-    Repository: https://github.com/5fish/svt-av1-psy .
-    Windows build: https://github.com/Akatmks/svt-av1-psy-quality/releases .
-    Linux build: `Build/linux/build.sh --native --static --release --enable-lto --enable-pgo` with clang highly recommended over gcc.
+    Source Repository & Builds: https://github.com/5fish/svt-av1 .
 
-    For high fidelity encodes, start at `--preset 0 --crf 12.00`.
-    You should regrain and do every other filtering just as you would for a high fidelity x265 encode. This will work fine.
-    For even better efficiency, you can offload high frequency part of the regraining noise onto AV1's film grain layer by writing a photon noise table.
+    Compared to the `settings_builder_5fish_svt_av1_mini_high_dlf`, this version works best with clean sources.
+    Ideally you want to remove temporal noise as much as you can without damaging texture before sending to the encoder.
 
-    For middle quality (for example, ~ 6 Mbps) encodes, start at `--preset 2 --crf 20.00`.
-    For most cases, you should be able to rely on writing a good photon noise table instead of regraining to achieve best detail retention for the given filesize. The builtin photon noise table of `SVTAV1` can deal with some basic situations as well. Otherwise you can do all other filtering as normal and make sure they are as protective as they can.
-
-    For mini encodes, start at `--preset 2 --crf 28.00`.
-    You want to remove temporal noise as much as you can while keeping static texture intact. Do not regrain for mini encode. Other than this, you want to still make every process including denoise and deband protective.
-
-    If it's a source with very heavy artistic temporal noise and you would not or could not remove the temporal noise, but you still want to get it to a very small filesize (< 3 Mbps), you should use SVT-AV1-Essential instead, as SVT-AV1-Essential throws away information more aggressively and can achieve a good looking result in noisy source even at very small filesize.
-
-    For both middle quality and mini encodes, `--preset 2` is preferred over slower `--preset 0`. Specifically this is because, internally, different `--preset` uses different methods to search for the best encoding option for each block. Without a high fidelity specific parameter (`--satd-bias`) that's internally enabled at `--crf [<= 16.00]`, it is better to use the `--preset 2`'s search strategy rather than `--preset 0`'s search strategy.
-
-    After setting up `--preset` and `--crf`, you should set a good `--lineart-psy-bias` and `--texture-psy-bias` value depending on how much effort you want to spend on them.
-
-    `--lineart-psy-bias 3` is generally good for all sources, especially sources without weak lineart and easier to handle.
-    `--lineart-psy-bias 4` puts a little bit more focus on weak lineart retention than `--lineart-psy-bias 3`.
-    `--lineart-psy-bias 5` and above is optimised for weak lineart retention. Some features here trade overall efficiency for better weak lineart retention, and some features here are tuned very aggressively and may cause issues in texture heavy sources.
-
-    `--texture-psy-bias 2` is fine to use on sources with little texture.
-    `--texture-psy-bias 3` puts a little bit of focus on texture, and can be used on sources with occasional texture.
-    `--texture-psy-bias 4` is suitable for sources with detailed texture. At this level, it starts to harm especially weak lineart in clean sources a little bit, but should still generally be fine for most sources.
-    `--texture-psy-bias 5` and above is suitabled for encodes where texture retention is a great priority, or when the source is very texture heavy or covered by a layer of static noise.
-
-    For better explanations of parameters, and to adjust the encoder beyond the two main `-psy-bias`s, check the `Docs/Parameters.md` file in encoder's GitHub.
-    For how to set the parameters for your source, as well as how to generate your own photon noise table, check the guides section in the AV1 weeb server, specifically “High effort high quality AV1 encode note collection”.
+    If you want to adjust the parameters for your source, check the Usage section in `README.md` in encoder's GitHub repository.
 
     To use this settings_builder,
     ```py
-    settings = settings_builder_5fish_svt_av1_psy(...)
+    settings = settings_builder_5fish_svt_av1_mini()
     mini = SVTAV1(**settings, sd_clip=src).encode(final)
     ```
     """
     args = dict[str, Any]()
-    args["_settings_builder_id"] = r"SVT-AV1-PSY \[5fish"
+    args["_settings_builder_id"] = r"SVT-AV1 \[5fish"
 
-    for k in inspect.getfullargspec(settings_builder_5fish_svt_av1_psy).args:
+    for k in inspect.getfullargspec(settings_builder_5fish_svt_av1_mini).args:
+        if locals()[k] is not None:
+            args[k] = locals()[k]
+
+    return args | kwargs
+
+def settings_builder_5fish_svt_av1_mini_high_dlf(
+    preset: int = 2,
+    crf: float = 26.00,
+    lineart_psy_bias: int = 5,
+    texture_psy_bias: int = 4,
+    dlf_bias_max_dlf: str | None = "24,4",
+    dlf_bias_min_dlf: str | None = "16,0",
+    dlf_sharpness: int | None = 7,
+    texture_cdef_bias_max_cdef: str | None = "0,0,0,0",
+    progress: int | None = 2,
+    **kwargs,
+) -> dict[str, Any]:
+    """
+    This is a settings_builder for 5fish/SVT-AV1.
+    These parameters correspond to early July 2026 version of the encoder.
+
+    Source Repository & Builds: https://github.com/5fish/svt-av1 .
+
+    Compared to the `settings_builder_5fish_svt_av1_mini`, this high DLF version is suitable for noisy or even regrained sources.
+
+    If you want to adjust the parameters for your source, check the Usage section in `README.md` in encoder's GitHub repository.
+
+    To use this settings_builder,
+    ```py
+    settings = settings_builder_5fish_svt_av1_mini_high_dlf()
+    mini = SVTAV1(**settings, sd_clip=src).encode(final)
+    ```
+    """
+    args = dict[str, Any]()
+    args["_settings_builder_id"] = r"SVT-AV1 \[5fish"
+
+    for k in inspect.getfullargspec(settings_builder_5fish_svt_av1_mini_high_dlf).args:
         if locals()[k] is not None:
             args[k] = locals()[k]
 
@@ -294,9 +342,6 @@ def settings_builder_svt_av1_essential(
     Repository: https://github.com/nekotrix/SVT-AV1-Essential .
     Windows build: https://github.com/Akatmks/svt-av1-psy-quality/releases .
     Linux build: apply patches if available, and build with `Build/linux/build.sh --native --static --release --enable-lto --enable-pgo` with clang highly recommended over gcc.
-
-    SVT-AV1-Essential is better for mini encodes and is optimised to give a good looking result given any source, with or without filtering.
-    You should not regrain before sending to SVT-AV1.
 
     For higer quality mini and non mini encodes, check out `settings_builder_5fish_svt_av1_psy`.
 

--- a/vsmuxtools/video/settings.py
+++ b/vsmuxtools/video/settings.py
@@ -235,6 +235,9 @@ def settings_builder_5fish_svt_av1_high_quality(
 
     Source Repository & Builds: https://github.com/5fish/svt-av1 .
 
+    You can denoise or regrain as normal before sending to the encoder.
+    However, utilising the film grain layer instead of regrain will be much more efficient.
+
     This settings_builder uses `--preset 0`. If it is too slow, you can switch to `--preset 2` without losing much quality.
 
     If you want to adjust the parameters for your source, check the Usage section in `README.md` in encoder's GitHub repository.
@@ -268,7 +271,7 @@ def settings_builder_5fish_svt_av1_mini(
 
     Source Repository & Builds: https://github.com/5fish/svt-av1 .
 
-    Compared to the `settings_builder_5fish_svt_av1_mini_high_dlf`, this version works best with clean sources.
+    Compared to the `settings_builder_5fish_svt_av1_mini_high_dlf`, this version works best with clean sources without regrain.
     Ideally you want to remove temporal noise as much as you can without damaging texture before sending to the encoder.
 
     If you want to adjust the parameters for your source, check the Usage section in `README.md` in encoder's GitHub repository.
@@ -290,12 +293,11 @@ def settings_builder_5fish_svt_av1_mini(
 
 def settings_builder_5fish_svt_av1_mini_high_dlf(
     preset: int = 2,
-    crf: float = 26.00,
-    lineart_psy_bias: int = 5,
-    texture_psy_bias: int = 4,
+    crf: float = 27.00,
+    lineart_psy_bias: int = 3,
+    texture_psy_bias: int = 5,
     dlf_bias_max_dlf: str | None = "24,4",
     dlf_bias_min_dlf: str | None = "16,0",
-    dlf_sharpness: int | None = 7,
     texture_cdef_bias_max_cdef: str | None = "0,0,0,0",
     progress: int | None = 2,
     **kwargs,
@@ -306,7 +308,8 @@ def settings_builder_5fish_svt_av1_mini_high_dlf(
 
     Source Repository & Builds: https://github.com/5fish/svt-av1 .
 
-    Compared to the `settings_builder_5fish_svt_av1_mini`, this high DLF version is suitable for noisy or even regrained sources.
+    Compared to the `settings_builder_5fish_svt_av1_mini`, this high DLF version is suitable for very noisy or regrained sources.
+    Denoise is not preferred even for very noisy sources.
 
     If you want to adjust the parameters for your source, check the Usage section in `README.md` in encoder's GitHub repository.
 
@@ -340,7 +343,7 @@ def settings_builder_svt_av1_essential(
     These parameters correspond to v4.0.1-Essential.
 
     Repository: https://github.com/nekotrix/SVT-AV1-Essential .
-    Windows build: https://github.com/Akatmks/svt-av1-psy-quality/releases .
+    Windows build: https://github.com/Akatmks/SVT-AV1-Builds .
     Linux build: apply patches if available, and build with `Build/linux/build.sh --native --static --release --enable-lto --enable-pgo` with clang highly recommended over gcc.
 
     For higer quality mini and non mini encodes, check out `settings_builder_5fish_svt_av1_psy`.


### PR DESCRIPTION
* Update 5fish/svt-av1-psy to 5fish/SVT-AV1.  
* Split `settings_builder_5fish_svt_av1` into 3 so that it's easier to use.  
* Increase max scene length to `321` as `--balancing-q-bias` system is now considered very stable and safe and has not had any issues with longer scene length.  

Thank you!  