### PR TITLE
SVTAV1: Add sd_cache parameter to prevent cache collision

### DIFF
--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -240,7 +240,7 @@ class SVTAV1(VideoEncoder):
     """
 
     sd_clip: vs.VideoNode | src_file | None = None
-    sd_cache_key: str | int | bool | None = None
+    sd_cache_key: str | int | bool | None = True
     light_photon_noise: bool = True
     resumable: bool = True
     quiet_merging: bool = True
@@ -338,14 +338,14 @@ class SVTAV1(VideoEncoder):
 
             if self.sd_cache_key == False:
                 cache = None
-            elif isinstance(self.sd_cache_key, (str, int)):
-                cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache-{self.sd_cache_key}.json"
-            else:
+            elif self.sd_cache_key == True or self.sd_cache_key is None:
                 sd_clip_path = get_prop(sd_clip, "IdxFilePath", t=str, default=None)
                 if sd_clip_path:
                     cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache-{Path(sd_clip_path).name}.json"
                 else:
                     cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache.json"
+            else:
+                cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache-{self.sd_cache_key}.json"
 
             try:
                 assert cache.exists()

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -368,6 +368,9 @@ class SVTAV1(VideoEncoder):
                         "frames": sd_clip.num_frames,
                         "scenecuts": sd_keyframes,
                     }
+
+                    cache.parent.mkdir(parents=True, exist_ok=True)
+
                     with cache.open("w") as cache_f:
                         json.dump(cache_config, cache_f)
 

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -225,6 +225,10 @@ class SVTAV1(VideoEncoder):
     :param sd_clip:            Perform scene detection for the encoder.
                                Can either be a straight up VideoNode or a SRC_FILE/FileInfo from this package.
                                It is recommended to use this scene detection for 5fish/SVT-AV1-PSY with the `--balancing-q-bias` system, while for SVT-AV1-Essential, you can rely on its own internal scene detection.
+    :param sd_cache:           Toggle or customize scene detection caching.
+                               Set to True to enable caching using the source filename as an identifier.
+                               Set to False to disable the scene detection cache entirely.
+                               Pass a string or integer (e.g., an episode number) to specify a custom cache identifier.
     :param light_photon_noise: Add a layer of light photon noise on top, serving a similar role as a light regrain / dither.
                                For a layer of noise with different strength or coarseness, you can generate it yourself following the guide available in AV1 weeb server.
                                On supported forks, you may also use `--photon-noise` parameter to apply a basic photon noise with configurable strength but not coarseness.
@@ -234,17 +238,14 @@ class SVTAV1(VideoEncoder):
     :param force_webm:         Force WebM output (only applies to SVT-AV1-Essential v4.0.1+).
                                When disabled, the format is chosen based on the output filename, allowing you to output to IVF.
                                Has no effect on other forks.
-    :param sd_cache_key:       Key to make the generated scene detection cache file uniquely identifiable.
-                               For example, when encoding several episodes in a show, this could be set as the episode number.
-                               If nothing is passed, the clip's source filename will be used. Passing False will prevent the cache file from being generated.
     """
 
     sd_clip: vs.VideoNode | src_file | None = None
+    sd_cache: str | int | bool = True
     light_photon_noise: bool = True
     resumable: bool = True
     quiet_merging: bool = True
     force_webm: bool = True
-    sd_cache_key: str | int | bool | None = True
     _encoder_id: str | None = None
     _settings_builder_id: str | None = None
 
@@ -336,16 +337,20 @@ class SVTAV1(VideoEncoder):
             if sd_clip.num_frames != clip.num_frames:
                 raise error("Scene detection clip `sd_clip` has different length than the `clip` being encoded", self)
 
-            if self.sd_cache_key == False:
-                cache = None
-            elif self.sd_cache_key == True or self.sd_cache_key is None:
+            if self.sd_cache == True:
                 sd_clip_path = get_prop(sd_clip, "IdxFilePath", t=str, default=None)
                 if sd_clip_path:
                     cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache-{Path(sd_clip_path).name}.json"
                 else:
+                    warn(
+                        "Failed to identify source filename; using default cache filename. Pass a unique ID or string to 'sd_cache' to prevent collisions during batch encodes.",
+                        self,
+                    )
                     cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache.json"
+            elif self.sd_cache == False:
+                cache = None
             else:
-                cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache-{self.sd_cache_key}.json"
+                cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache-{self.sd_cache}.json"
 
             try:
                 assert cache is not None

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -1,6 +1,6 @@
 import shlex
 import subprocess
-from vstools import finalize_clip, vs, ChromaLocation
+from vstools import finalize_clip, vs, ChromaLocation, get_prop
 from pathlib import Path
 from muxtools import get_executable, VideoFile, PathLike, make_output, warn, get_setup_attr, ensure_path, info, debug, get_workdir, error
 from muxtools.utils.env import get_binary_version
@@ -225,6 +225,9 @@ class SVTAV1(VideoEncoder):
     :param sd_clip:            Perform scene detection for the encoder.
                                Can either be a straight up VideoNode or a SRC_FILE/FileInfo from this package.
                                It is recommended to use this scene detection for 5fish/SVT-AV1-PSY with the `--balancing-q-bias` system, while for SVT-AV1-Essential, you can rely on its own internal scene detection.
+    :param sd_cache_key:       Key to make the generated scene detection cache file uniquely identifiable. For example, when encoding several episodes in a show, this can be the episode number.
+                               If nothing is passed, the clip's source filename will be used as the key. No key will be used if it can't be found. Passing False will prevent the cache file from being generated.
+                               This prevents the cache from being overwritten by subsequent episodes or incorrectly reusing the cache for a different episode.
     :param light_photon_noise: Add a layer of light photon noise on top, serving a similar role as a light regrain / dither.
                                For a layer of noise with different strength or coarseness, you can generate it yourself following the guide available in AV1 weeb server.
                                On supported forks, you may also use `--photon-noise` parameter to apply a basic photon noise with configurable strength but not coarseness.
@@ -237,6 +240,7 @@ class SVTAV1(VideoEncoder):
     """
 
     sd_clip: vs.VideoNode | src_file | None = None
+    sd_cache_key: str | int | bool | None = None
     light_photon_noise: bool = True
     resumable: bool = True
     quiet_merging: bool = True
@@ -332,7 +336,16 @@ class SVTAV1(VideoEncoder):
             if sd_clip.num_frames != clip.num_frames:
                 raise error("Scene detection clip `sd_clip` has different length than the `clip` being encoded", self)
 
-            cache = get_workdir() / "svt_av1_scene_detection_cache.json"
+            if self.sd_cache_key == False:
+                cache = None
+            elif isinstance(self.sd_cache_key, (str, int)):
+                cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache-{self.sd_cache_key}.json"
+            else:
+                sd_clip_path = get_prop(sd_clip, "IdxFilePath", t=str, default=None)
+                if sd_clip_path:
+                    cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache-{Path(sd_clip_path).name}.json"
+                else:
+                    cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache.json"
 
             try:
                 with cache.open("r") as cache_f:
@@ -348,12 +361,13 @@ class SVTAV1(VideoEncoder):
                 info("Performing scene detection...", self)
                 sd_keyframes = generate_svt_av1_keyframes(sd_clip)
 
-                cache_config = {
-                    "frames": sd_clip.num_frames,
-                    "scenecuts": sd_keyframes,
-                }
-                with cache.open("w") as cache_f:
-                    json.dump(cache_config, cache_f)
+                if cache is not None:
+                    cache_config = {
+                        "frames": sd_clip.num_frames,
+                        "scenecuts": sd_keyframes,
+                    }
+                    with cache.open("w") as cache_f:
+                        json.dump(cache_config, cache_f)
 
                 info("Scene detection complete.", self)
 

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -348,6 +348,8 @@ class SVTAV1(VideoEncoder):
                     cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache.json"
 
             try:
+                assert cache.exists()
+
                 with cache.open("r") as cache_f:
                     cache_config = json.load(cache_f)
 

--- a/vsmuxtools/video/encoders/standalone.py
+++ b/vsmuxtools/video/encoders/standalone.py
@@ -225,9 +225,6 @@ class SVTAV1(VideoEncoder):
     :param sd_clip:            Perform scene detection for the encoder.
                                Can either be a straight up VideoNode or a SRC_FILE/FileInfo from this package.
                                It is recommended to use this scene detection for 5fish/SVT-AV1-PSY with the `--balancing-q-bias` system, while for SVT-AV1-Essential, you can rely on its own internal scene detection.
-    :param sd_cache_key:       Key to make the generated scene detection cache file uniquely identifiable. For example, when encoding several episodes in a show, this can be the episode number.
-                               If nothing is passed, the clip's source filename will be used as the key. No key will be used if it can't be found. Passing False will prevent the cache file from being generated.
-                               This prevents the cache from being overwritten by subsequent episodes or incorrectly reusing the cache for a different episode.
     :param light_photon_noise: Add a layer of light photon noise on top, serving a similar role as a light regrain / dither.
                                For a layer of noise with different strength or coarseness, you can generate it yourself following the guide available in AV1 weeb server.
                                On supported forks, you may also use `--photon-noise` parameter to apply a basic photon noise with configurable strength but not coarseness.
@@ -237,14 +234,17 @@ class SVTAV1(VideoEncoder):
     :param force_webm:         Force WebM output (only applies to SVT-AV1-Essential v4.0.1+).
                                When disabled, the format is chosen based on the output filename, allowing you to output to IVF.
                                Has no effect on other forks.
+    :param sd_cache_key:       Key to make the generated scene detection cache file uniquely identifiable.
+                               For example, when encoding several episodes in a show, this could be set as the episode number.
+                               If nothing is passed, the clip's source filename will be used. Passing False will prevent the cache file from being generated.
     """
 
     sd_clip: vs.VideoNode | src_file | None = None
-    sd_cache_key: str | int | bool | None = True
     light_photon_noise: bool = True
     resumable: bool = True
     quiet_merging: bool = True
     force_webm: bool = True
+    sd_cache_key: str | int | bool | None = True
     _encoder_id: str | None = None
     _settings_builder_id: str | None = None
 
@@ -348,7 +348,7 @@ class SVTAV1(VideoEncoder):
                 cache = get_workdir() / ".vsjet" / "vsmuxtools" / f"svt_av1_sd_cache-{self.sd_cache_key}.json"
 
             try:
-                assert cache.exists()
+                assert cache is not None
 
                 with cache.open("r") as cache_f:
                     cache_config = json.load(cache_f)


### PR DESCRIPTION
If encoding different clips with the same frame count, the scene detection cache file will wrongly be reused. This PR allows you to toggle the cache file and allows users to pass their own string to make the cache file unique. The clip's source filename is used by default if none is specified.

I also adjusted the code to place the cache files under `.vsjet\vsmuxtools\`. I don't think this is done anywhere else in vsmuxtools, but it matches the behaviour of other jet tools like vssource.

Let me know if any changes are needed